### PR TITLE
Remove "-mmacosx-min-version" everywhere.

### DIFF
--- a/unix/boot/spp/xc.c
+++ b/unix/boot/spp/xc.c
@@ -804,17 +804,8 @@ passflag:		    mkobject = YES;
 	if (useg95 == 0) {
 	    if ((irafarch = os_getenv("IRAFARCH"))) {
 	        if (strcmp (irafarch, "macosx") == 0) {
-		    /*
-	            arglist[nargs++] = "-arch";
-	    	    arglist[nargs++] = "ppc";
-		    */
-	            arglist[nargs++] = "-arch";
-	    	    arglist[nargs++] = "i386";
 	    	    arglist[nargs++] = "-m32";
-	    	    arglist[nargs++] = "-mmacosx-version-min=10.4";
 	        } else if (strcmp (irafarch, "macintel") == 0) {
-	            arglist[nargs++] = "-arch";
-	    	    arglist[nargs++] = "x86_64";
 	    	    arglist[nargs++] = "-m64";
 		}
 	    }
@@ -886,17 +877,8 @@ passflag:		    mkobject = YES;
 	if (useg95 == 0) {
 	    if ((irafarch = os_getenv("IRAFARCH"))) {
                 if (strcmp (irafarch, "macosx") == 0) {
-		    /*
-                    arglist[nargs++] = "-arch";
-                    arglist[nargs++] = "ppc";
-		    */
-                    arglist[nargs++] = "-arch";
-                    arglist[nargs++] = "i386";
                     arglist[nargs++] = "-m32";
-	    	    arglist[nargs++] = "-mmacosx-version-min=10.4";
                 } else if (strcmp (irafarch, "macintel") == 0) {
-                    arglist[nargs++] = "-arch";
-                    arglist[nargs++] = "x86_64";
                     arglist[nargs++] = "-m64";
                 }
 
@@ -999,17 +981,8 @@ passflag:		    mkobject = YES;
 	if (useg95 == 0) {
 	    if ((irafarch = os_getenv("IRAFARCH"))) {
                 if (strcmp (irafarch, "macosx") == 0) {
-		    /*
-                    arglist[nargs++] = "-arch";
-                    arglist[nargs++] = "ppc";
-		    */
-                    arglist[nargs++] = "-arch";
-                    arglist[nargs++] = "i386";
                     arglist[nargs++] = "-m32";
-	    	    arglist[nargs++] = "-mmacosx-version-min=10.4";
                 } else if (strcmp (irafarch, "macintel") == 0) {
-                    arglist[nargs++] = "-arch";
-                    arglist[nargs++] = "x86_64";
                     arglist[nargs++] = "-m64";
                 }
 
@@ -1084,17 +1057,8 @@ passflag:		    mkobject = YES;
 #ifdef MACOSX
 	if (useg95 == 0 && (irafarch = os_getenv("IRAFARCH"))) {
             if (strcmp (irafarch, "macosx") == 0) {
-		/*
-                arglist[nargs++] = "-arch";
-                arglist[nargs++] = "ppc";
-		*/
-                arglist[nargs++] = "-arch";
-                arglist[nargs++] = "i386";
                 arglist[nargs++] = "-m32";
-	    	arglist[nargs++] = "-mmacosx-version-min=10.4";
             } else if (strcmp (irafarch, "macintel") == 0) {
-                arglist[nargs++] = "-arch";
-                arglist[nargs++] = "x86_64";
                 arglist[nargs++] = "-m64";
             }
 	}

--- a/unix/hlib/irafuser.csh
+++ b/unix/hlib/irafuser.csh
@@ -88,13 +88,14 @@ case freebsd:
     breaksw
 
 case macosx:
-    setenv HSI_CF "-O -DMACOSX -w -Wunused -arch i386 -m32 -mmacosx-version-min=10.4"
-    setenv HSI_XF "-Inolibc -/DMACOSX -w -/Wunused -/m32 -/arch -//i386"
-    setenv HSI_FF "-O -arch i386 -m32 -DBLD_KERNEL -mmacosx-version-min=10.4"
-    setenv HSI_LF "-arch i386 -m32 -mmacosx-version-min=10.4"
+    setenv HSI_CF "-O -DMACOSX -w -Wunused -m32"
+    setenv HSI_XF "-Inolibc -/DMACOSX -w -/Wunused -/m32"
+    setenv HSI_FF "-O -m32 -DBLD_KERNEL"
+    setenv HSI_LF "-m32"
     setenv HSI_F77LIBS ""
     setenv HSI_LFLAGS ""
     setenv HSI_OSLIBS ""
+    setenv MACOSX_DEPLOYMENT_TARGET "10.5"
     set    mkzflags = "'lflags=-z'"
     breaksw
 
@@ -106,6 +107,7 @@ case macintel:
     setenv HSI_F77LIBS ""
     setenv HSI_LFLAGS ""
     setenv HSI_OSLIBS ""
+    setenv MACOSX_DEPLOYMENT_TARGET "10.5"
     set    mkzflags = "'lflags=-z'"
     breaksw
 

--- a/unix/hlib/irafuser.sh
+++ b/unix/hlib/irafuser.sh
@@ -34,10 +34,10 @@ case "$MACH" in
     ;;
 
   "macosx")
-    export HSI_CF="-O -DMACOSX -Wall -Wunused -arch i386 -m32 -mmacosx-version-min=10.4"
-    export HSI_XF="-Inolibc -/DMACOSX -w -/Wunused -/m32 -/arch -//i386"
-    export HSI_FF="-O -arch i386 -m32 -DBLD_KERNEL -mmacosx-version-min=10.4"
-    export HSI_LF="-arch i386 -m32 -mmacosx-version-min=10.4"
+    export HSI_CF="-O -DMACOSX -Wall -Wunused -m32"
+    export HSI_XF="-Inolibc -/DMACOSX -w -/Wunused -/m32"
+    export HSI_FF="-O -m32 -DBLD_KERNEL"
+    export HSI_LF="-m32"
     export HSI_F77LIBS=""
     export HSI_LFLAGS=""
     export HSI_OSLIBS=""

--- a/vendor/Makefile
+++ b/vendor/Makefile
@@ -21,9 +21,9 @@ CC 	  	= gcc
 CINCS  	  	= -I$(INCDIR) -I./
 ifeq  ($(PLATFORM), "Darwin")
     ifeq  ($(PLATFORM), "x86_64")
-        CARCH	= -m64 -mmacosx-version-min=10.5
+        CARCH	= -m64
     else
-        CARCH	= -arch i386 -arch ppc -m32 -mmacosx-version-min=10.4
+        CARCH	= -m32
     endif
 else
     CARCH	= 

--- a/vendor/cfitsio/mklibs
+++ b/vendor/cfitsio/mklibs
@@ -9,7 +9,7 @@ setenv CXX 	"g++"
 
 if ($?PLMACH) then
   if ($PLMACH == "macosx") then
-    setenv CFLAGS "-mmacosx-version-min=10.5 -DDarwin"
+    setenv CFLAGS "-DDarwin"
   endif
 endif
 

--- a/vendor/readline/Makefile
+++ b/vendor/readline/Makefile
@@ -89,15 +89,15 @@ PLMACH          := $(shell uname -m)
 
 ifeq ($(PLATFORM),Darwin)
     ifeq ($(PLMACH),x86_64)
-        CARCH   = -m64 -mmacosx-version-min=10.5
+        CARCH   = -m64
     else
-        CARCH   = -arch i386 -m32 -mmacosx-version-min=10.4
+        CARCH   = -m32
     endif
     ifdef IRAFARCH
         ifeq ($(IRAFARCH),macintel)
-            CARCH = -m64 -mmacosx-version-min=10.5
+            CARCH = -m64
         else
-            CARCH = -arch i386 -m32 -mmacosx-version-min=10.5
+            CARCH = -m32
         endif
     endif
 else

--- a/vendor/readline/Makefile.in
+++ b/vendor/readline/Makefile.in
@@ -89,15 +89,15 @@ PLMACH          := $(shell uname -m)
 
 ifeq ($(PLATFORM),Darwin)
     ifeq ($(PLMACH),x86_64)
-        CARCH   = -m64 -mmacosx-version-min=10.5
+        CARCH   = -m64
     else
-        CARCH   = -arch i386 -m32 -mmacosx-version-min=10.4
+        CARCH   = -m32
     endif
     ifdef IRAFARCH
         ifeq ($(IRAFARCH),macintel)
-            CARCH = -m64 -mmacosx-version-min=10.5
+            CARCH = -m64
         else
-            CARCH = -arch i386 -m32 -mmacosx-version-min=10.5
+            CARCH = -m32
         endif
     endif
 else

--- a/vendor/voclient/Makefile
+++ b/vendor/voclient/Makefile
@@ -24,9 +24,9 @@ CC 	  	= gcc
 CINCS  	  	= -I$(INCDIR) -I./
 ifeq  ($(PLATFORM), "Darwin")
     ifeq  ($(PLATFORM), "x86_64")
-        CARCH	= -m64 -mmacosx-version-min=10.5
+        CARCH	= -m64
     else
-        CARCH	= -arch i386 -arch ppc -m32 -mmacosx-version-min=10.4
+        CARCH	= -m32
     endif
 else
     CARCH	= 

--- a/vendor/voclient/common/Makefile
+++ b/vendor/voclient/common/Makefile
@@ -21,9 +21,9 @@ CC 	  	= gcc
 CINCS  	  	= -I$(INCDIR) -I./
 ifeq ($(PLATFORM),Darwin)
     ifeq  ($(PLATFORM),x86_64)
-        CARCH	= -m64 -mmacosx-version-min=10.5
+        CARCH	= -m64
     else
-        CARCH	= -mmacosx-version-min=10.5
+        CARCH	= -m32
     endif
     LIBS	= -lm -lc
 else

--- a/vendor/voclient/common/curl-7.20.1/Makefile
+++ b/vendor/voclient/common/curl-7.20.1/Makefile
@@ -128,8 +128,8 @@ AUTOMAKE = ${SHELL} "/iraf/iraf/vendor/voclient/common/curl/missing" --run autom
 AWK = awk
 CC = gcc
 CCDEPMODE = depmode=gcc3
-CFLAGS = -arch i386 -m32 -mmacosx-version-min=10.4 -g0 -O2 -Wno-system-headers
-CONFIGURE_OPTIONS = " '--prefix=/iraf/iraf/vendor/voclient/' '--exec-prefix=/iraf/iraf/vendor/voclient/' '--disable-shared' '' '--disable-ftp' '' '--disable-file' '' '--disable-ldap' '' '--disable-ldaps' '' '--disable-proxy' '' '--disable-dict' '' '--disable-telnet' '' '--disable-tftp' '' '--disable-manual' '' '--disable-ipv6' '' '--disable-ares' '' '--disable-sspi' '' '--disable-crypto-auth' '' '--without-krb4' '' '--without-ssl' '' '--without-zlib' '' '--without-libssh2' '' '--without-gnutls' '' '--without-nss' '' '--without-ca-path' '' '--without-libidn' 'build_alias=' 'host_alias=' 'target_alias=' 'CC=gcc' 'CFLAGS=-arch i386 -m32 -mmacosx-version-min=10.4' 'LDFLAGS=-arch i386 -m32 -mmacosx-version-min=10.4'"
+CFLAGS = -m32 -g0 -O2 -Wno-system-headers
+CONFIGURE_OPTIONS = " '--prefix=/iraf/iraf/vendor/voclient/' '--exec-prefix=/iraf/iraf/vendor/voclient/' '--disable-shared' '' '--disable-ftp' '' '--disable-file' '' '--disable-ldap' '' '--disable-ldaps' '' '--disable-proxy' '' '--disable-dict' '' '--disable-telnet' '' '--disable-tftp' '' '--disable-manual' '' '--disable-ipv6' '' '--disable-ares' '' '--disable-sspi' '' '--disable-crypto-auth' '' '--without-krb4' '' '--without-ssl' '' '--without-zlib' '' '--without-libssh2' '' '--without-gnutls' '' '--without-nss' '' '--without-ca-path' '' '--without-libidn' 'build_alias=' 'host_alias=' 'target_alias=' 'CC=gcc' 'CFLAGS=-m32' 'LDFLAGS=-m32'"
 CPP = gcc -E
 CPPFLAGS = 
 CROSSCOMPILING_FALSE = 
@@ -176,7 +176,7 @@ INSTALL_STRIP_PROGRAM = ${SHELL} $(install_sh) -c -s
 IPV6_ENABLED = 
 KRB4_ENABLED = 
 LD = /usr/llvm-gcc-4.2/libexec/gcc/i686-apple-darwin11/4.2.1/ld
-LDFLAGS = -arch i386 -m32 -mmacosx-version-min=10.4
+LDFLAGS = -m32
 LIBCURL_LIBS = 
 LIBOBJS = 
 LIBS = 

--- a/vendor/voclient/common/curl-7.20.1/curl-config
+++ b/vendor/voclient/common/curl-7.20.1/curl-config
@@ -136,18 +136,18 @@ while test $# -gt 0; do
 	   CURLLIBDIR=""
 	fi
 	if test "Xyes" = "Xyes"; then
-	  echo ${CURLLIBDIR}-lcurl -arch i386 -m32 -mmacosx-version-min=10.4  
+	  echo ${CURLLIBDIR}-lcurl -m32  
 	else
-	  echo ${CURLLIBDIR}-lcurl -arch i386 -m32 -mmacosx-version-min=10.4 
+	  echo ${CURLLIBDIR}-lcurl -m32 
 	fi
 	;;
 
     --static-libs)
-	echo ${exec_prefix}/lib/libcurl.a -arch i386 -m32 -mmacosx-version-min=10.4  
+	echo ${exec_prefix}/lib/libcurl.a -m32  
 	;;
 
     --configure)
-      echo " '--prefix=/iraf/iraf/vendor/voclient/' '--exec-prefix=/iraf/iraf/vendor/voclient/' '--disable-shared' '' '--disable-ftp' '' '--disable-file' '' '--disable-ldap' '' '--disable-ldaps' '' '--disable-proxy' '' '--disable-dict' '' '--disable-telnet' '' '--disable-tftp' '' '--disable-manual' '' '--disable-ipv6' '' '--disable-ares' '' '--disable-sspi' '' '--disable-crypto-auth' '' '--without-krb4' '' '--without-ssl' '' '--without-zlib' '' '--without-libssh2' '' '--without-gnutls' '' '--without-nss' '' '--without-ca-path' '' '--without-libidn' 'build_alias=' 'host_alias=' 'target_alias=' 'CC=gcc' 'CFLAGS=-arch i386 -m32 -mmacosx-version-min=10.4' 'LDFLAGS=-arch i386 -m32 -mmacosx-version-min=10.4'"
+      echo " '--prefix=/iraf/iraf/vendor/voclient/' '--exec-prefix=/iraf/iraf/vendor/voclient/' '--disable-shared' '' '--disable-ftp' '' '--disable-file' '' '--disable-ldap' '' '--disable-ldaps' '' '--disable-proxy' '' '--disable-dict' '' '--disable-telnet' '' '--disable-tftp' '' '--disable-manual' '' '--disable-ipv6' '' '--disable-ares' '' '--disable-sspi' '' '--disable-crypto-auth' '' '--without-krb4' '' '--without-ssl' '' '--without-zlib' '' '--without-libssh2' '' '--without-gnutls' '' '--without-nss' '' '--without-ca-path' '' '--without-libidn' 'build_alias=' 'host_alias=' 'target_alias=' 'CC=gcc' 'CFLAGS=-m32' 'LDFLAGS=-m32'"
     ;;
 
     *)

--- a/vendor/voclient/common/curl-7.20.1/libtool
+++ b/vendor/voclient/common/curl-7.20.1/libtool
@@ -138,7 +138,7 @@ old_postuninstall_cmds=""
 LTCC="gcc"
 
 # LTCC compiler flags.
-LTCFLAGS="-arch i386 -m32 -mmacosx-version-min=10.4 -g0 -O2 -Wno-system-headers"
+LTCFLAGS="-m32 -g0 -O2 -Wno-system-headers"
 
 # Take the output of nm and produce a listing of raw symbols and C names.
 global_symbol_pipe="sed -n -e 's/^.*[	 ]\\([BCDEGRST][BCDEGRST]*\\)[	 ][	 ]*_\\([_A-Za-z][_A-Za-z0-9]*\\)\$/\\1 _\\2 \\2/p'"

--- a/vendor/voclient/common/expat-2.0.1/Makefile.in
+++ b/vendor/voclient/common/expat-2.0.1/Makefile.in
@@ -44,15 +44,15 @@ CC              = gcc
 CINCS           = -I$(INCDIR)  -I.
 ifeq ($(PLATFORM),Darwin)
     ifeq ($(PLMACH),x86_64)
-        CARCH   = -m64 -mmacosx-version-min=10.5
+        CARCH   = -m64
     else
-        CARCH   = -arch i386 -m32 -mmacosx-version-min=10.4
+        CARCH   = -m32
     endif
     ifdef IRAFARCH
         ifeq ($(IRAFARCH),macintel)
-            CARCH = -m64 -mmacosx-version-min=10.5
+            CARCH = -m64
         else
-            CARCH = -arch i386 -m32 -mmacosx-version-min=10.5
+            CARCH = -m32
         endif
     endif
 else

--- a/vendor/voclient/common/mklibs
+++ b/vendor/voclient/common/mklibs
@@ -14,13 +14,13 @@ setenv PLMACH   `uname -m`
 if ($PLATFORM == "Darwin") then
    if ( $?IRAFARCH ) then
        if ( "$IRAFARCH" == "macintel" ) then
-           setenv CFLAGS   '-m64 -mmacosx-version-min=10.4'
-           setenv LDFLAGS  '-m64 -mmacosx-version-min=10.4'
-           setenv LADD     '-m64 -mmacosx-version-min=10.4'
+           setenv CFLAGS   '-m64'
+           setenv LDFLAGS  '-m64'
+           setenv LADD     '-m64'
        else
-           setenv CFLAGS   '-arch i386 -m32 -mmacosx-version-min=10.4'
-           setenv LDFLAGS  '-arch i386 -m32 -mmacosx-version-min=10.4'
-           setenv LADD     '-arch i386 -m32 -mmacosx-version-min=10.4'
+           setenv CFLAGS   '-m32'
+           setenv LDFLAGS  '-m32'
+           setenv LADD     '-m32'
        endif
    endif
    set	build_curl	= 1

--- a/vendor/voclient/include/Makefile
+++ b/vendor/voclient/include/Makefile
@@ -80,8 +80,8 @@ AUTOMAKE = ${SHELL} "/iraf/iraf/vendor/voclient/common/curl/missing" --run autom
 AWK = awk
 CC = gcc
 CCDEPMODE = depmode=gcc3
-CFLAGS = -arch i386 -m32 -mmacosx-version-min=10.4 -g0 -O2 -Wno-system-headers
-CONFIGURE_OPTIONS = " '--prefix=/iraf/iraf/vendor/voclient/' '--exec-prefix=/iraf/iraf/vendor/voclient/' '--disable-shared' '' '--disable-ftp' '' '--disable-file' '' '--disable-ldap' '' '--disable-ldaps' '' '--disable-proxy' '' '--disable-dict' '' '--disable-telnet' '' '--disable-tftp' '' '--disable-manual' '' '--disable-ipv6' '' '--disable-ares' '' '--disable-sspi' '' '--disable-crypto-auth' '' '--without-krb4' '' '--without-ssl' '' '--without-zlib' '' '--without-libssh2' '' '--without-gnutls' '' '--without-nss' '' '--without-ca-path' '' '--without-libidn' 'build_alias=' 'host_alias=' 'target_alias=' 'CC=gcc' 'CFLAGS=-arch i386 -m32 -mmacosx-version-min=10.4' 'LDFLAGS=-arch i386 -m32 -mmacosx-version-min=10.4'"
+CFLAGS = -m32 -g0 -O2 -Wno-system-headers
+CONFIGURE_OPTIONS = " '--prefix=/iraf/iraf/vendor/voclient/' '--exec-prefix=/iraf/iraf/vendor/voclient/' '--disable-shared' '' '--disable-ftp' '' '--disable-file' '' '--disable-ldap' '' '--disable-ldaps' '' '--disable-proxy' '' '--disable-dict' '' '--disable-telnet' '' '--disable-tftp' '' '--disable-manual' '' '--disable-ipv6' '' '--disable-ares' '' '--disable-sspi' '' '--disable-crypto-auth' '' '--without-krb4' '' '--without-ssl' '' '--without-zlib' '' '--without-libssh2' '' '--without-gnutls' '' '--without-nss' '' '--without-ca-path' '' '--without-libidn' 'build_alias=' 'host_alias=' 'target_alias=' 'CC=gcc' 'CFLAGS=-m32' 'LDFLAGS=-m32'"
 CPP = gcc -E
 CPPFLAGS = 
 CROSSCOMPILING_FALSE = 
@@ -128,7 +128,7 @@ INSTALL_STRIP_PROGRAM = ${SHELL} $(install_sh) -c -s
 IPV6_ENABLED = 
 KRB4_ENABLED = 
 LD = /usr/llvm-gcc-4.2/libexec/gcc/i686-apple-darwin11/4.2.1/ld
-LDFLAGS = -arch i386 -m32 -mmacosx-version-min=10.4
+LDFLAGS = -m32
 LIBCURL_LIBS = 
 LIBOBJS = 
 LIBS = 

--- a/vendor/voclient/include/curl/Makefile
+++ b/vendor/voclient/include/curl/Makefile
@@ -81,8 +81,8 @@ AUTOMAKE = ${SHELL} "/iraf/iraf/vendor/voclient/common/curl/missing" --run autom
 AWK = awk
 CC = gcc
 CCDEPMODE = depmode=gcc3
-CFLAGS = -arch i386 -m32 -mmacosx-version-min=10.4 -g0 -O2 -Wno-system-headers
-CONFIGURE_OPTIONS = " '--prefix=/iraf/iraf/vendor/voclient/' '--exec-prefix=/iraf/iraf/vendor/voclient/' '--disable-shared' '' '--disable-ftp' '' '--disable-file' '' '--disable-ldap' '' '--disable-ldaps' '' '--disable-proxy' '' '--disable-dict' '' '--disable-telnet' '' '--disable-tftp' '' '--disable-manual' '' '--disable-ipv6' '' '--disable-ares' '' '--disable-sspi' '' '--disable-crypto-auth' '' '--without-krb4' '' '--without-ssl' '' '--without-zlib' '' '--without-libssh2' '' '--without-gnutls' '' '--without-nss' '' '--without-ca-path' '' '--without-libidn' 'build_alias=' 'host_alias=' 'target_alias=' 'CC=gcc' 'CFLAGS=-arch i386 -m32 -mmacosx-version-min=10.4' 'LDFLAGS=-arch i386 -m32 -mmacosx-version-min=10.4'"
+CFLAGS = -m32 -g0 -O2 -Wno-system-headers
+CONFIGURE_OPTIONS = " '--prefix=/iraf/iraf/vendor/voclient/' '--exec-prefix=/iraf/iraf/vendor/voclient/' '--disable-shared' '' '--disable-ftp' '' '--disable-file' '' '--disable-ldap' '' '--disable-ldaps' '' '--disable-proxy' '' '--disable-dict' '' '--disable-telnet' '' '--disable-tftp' '' '--disable-manual' '' '--disable-ipv6' '' '--disable-ares' '' '--disable-sspi' '' '--disable-crypto-auth' '' '--without-krb4' '' '--without-ssl' '' '--without-zlib' '' '--without-libssh2' '' '--without-gnutls' '' '--without-nss' '' '--without-ca-path' '' '--without-libidn' 'build_alias=' 'host_alias=' 'target_alias=' 'CC=gcc' 'CFLAGS=-m32' 'LDFLAGS=-m32'"
 CPP = gcc -E
 CPPFLAGS = 
 CROSSCOMPILING_FALSE = 
@@ -129,7 +129,7 @@ INSTALL_STRIP_PROGRAM = ${SHELL} $(install_sh) -c -s
 IPV6_ENABLED = 
 KRB4_ENABLED = 
 LD = /usr/llvm-gcc-4.2/libexec/gcc/i686-apple-darwin11/4.2.1/ld
-LDFLAGS = -arch i386 -m32 -mmacosx-version-min=10.4
+LDFLAGS = -m32
 LIBCURL_LIBS = 
 LIBOBJS = 
 LIBS = 

--- a/vendor/voclient/libsamp/Makefile
+++ b/vendor/voclient/libsamp/Makefile
@@ -30,15 +30,15 @@ CINCS           = -I$(INCDIR)  -I.
 
 ifeq ($(PLATFORM),Darwin)
     ifeq ($(PLMACH),x86_64)
-        CARCH   = -m64 -mmacosx-version-min=10.5
+        CARCH   = -m64
     else
-        CARCH   = -arch i386 -m32 -mmacosx-version-min=10.4
+        CARCH   = -m32
     endif
     ifdef IRAFARCH
         ifeq ($(IRAFARCH),macintel)
-            CARCH = -m64 -mmacosx-version-min=10.5
+            CARCH = -m64
         else
-            CARCH = -arch i386 -m32 -mmacosx-version-min=10.5
+            CARCH = -m32
         endif
     endif
 else

--- a/vendor/voclient/libsamp/apps/Makefile
+++ b/vendor/voclient/libsamp/apps/Makefile
@@ -29,9 +29,9 @@ SHAREDLIB   = $(HERE)/$(LIBBASE).so.$(VERSION)
 
 ifeq ($(PLATFORM), "Darwin")
     ifeq  ($(PLMACH), "x86_64")
-        CARCH   = -m64 -mmacosx-version-min=10.5
+        CARCH   = -m64
     else
-        CARCH   = -arch i386 -arch ppc -m32 -mmacosx-version-min=10.4
+        CARCH   = -m32
     endif
 else
     CLIBS       = -lm -lc -lpthread

--- a/vendor/voclient/libsamp/examples/Makefile
+++ b/vendor/voclient/libsamp/examples/Makefile
@@ -33,16 +33,16 @@ CFLAGS 	    = -g -Wall -D$(PLATFORM) $(CINCS)
 
 ifeq ("$(PLATFORM)", "Darwin")
     ifeq  ("$(PLMACH)", "macintel")
-        CARCH   = -m64 -mmacosx-version-min=10.5
+        CARCH   = -m64
     else
-        CARCH   = -arch i386 -arch ppc -m32 -mmacosx-version-min=10.4
+        CARCH   = -m32
     endif
 else
     CLIBS       = -lm -lc -lpthread -lcurl
     CARCH       = -D$(PLATFORM)
 endif
 
-#CARCH   	= -arch i386 -arch ppc -m32 -mmacosx-version-min=10.4
+#CARCH   	= -m32
 CLIBS           = -lm -lc -lcurl -lpthread
 CFLAGS          = -g -Wall $(CARCH) -D$(PLATFORM) $(CINCS) -L./
 

--- a/vendor/voclient/libsamp/libxrpc/Makefile
+++ b/vendor/voclient/libsamp/libxrpc/Makefile
@@ -29,15 +29,15 @@ SHAREDLIB   = $(HERE)/$(LIBBASE).so.$(VERSION)
 CINCS   = -I./ -I./include -I../include -Ixmlrpc-c/lib/abyss/src
 ifeq ($(PLATFORM),Darwin)
     ifeq ($(PLMACH),x86_64)
-        CARCH   = -m64 -mmacosx-version-min=10.5
+        CARCH   = -m64
     else
-        CARCH   = -arch i386 -m32 -mmacosx-version-min=10.4
+        CARCH   = -m32
     endif
     ifdef IRAFARCH
         ifeq ($(IRAFARCH),macintel)
-            CARCH = -m64 -mmacosx-version-min=10.5
+            CARCH = -m64
         else
-            CARCH = -arch i386 -m32 -mmacosx-version-min=10.5
+            CARCH = -m32
         endif
     endif
 else

--- a/vendor/voclient/libsamp/libxrpc/mklibs
+++ b/vendor/voclient/libsamp/libxrpc/mklibs
@@ -16,13 +16,13 @@ set	build_xmlrpc	= 1
 if ($PLATFORM == "Darwin") then
    if ( $?IRAFARCH ) then
        if ( "$IRAFARCH" == "macintel" ) then
-   	   setenv CFLAGS   '-m64 -mmacosx-version-min=10.4'
-   	   setenv LDFLAGS  '-m64 -mmacosx-version-min=10.4'
-           setenv LADD     '-m64 -mmacosx-version-min=10.4'
+   	   setenv CFLAGS   '-m64'
+   	   setenv LDFLAGS  '-m64'
+           setenv LADD     '-m64'
        else
-   	   setenv CFLAGS   '-arch i386 -m32 -mmacosx-version-min=10.4'
-   	   setenv LDFLAGS  '-arch i386 -m32 -mmacosx-version-min=10.4'
-           setenv LADD     '-arch i386 -m32 -mmacosx-version-min=10.4'
+   	   setenv CFLAGS   '-m32'
+   	   setenv LDFLAGS  '-m32'
+           setenv LADD     '-m32'
        endif
    endif
 else

--- a/vendor/voclient/libsamp/libxrpc/xmlrpc-c-1.16.29/common.mk
+++ b/vendor/voclient/libsamp/libxrpc/xmlrpc-c-1.16.29/common.mk
@@ -33,11 +33,11 @@ GCC_CXX_WARNINGS = $(GCC_WARNINGS) -Woverloaded-virtual -Wsynth
 #
 CFLAGS_COMMON = -DNDEBUG
 ifeq ($(IRAFARCH),macintel)
-    CFLAGS_COMMON = -DNDEBUG -m64 -mmacosx-version-min=10.4
+    CFLAGS_COMMON = -DNDEBUG -m64
     LADD += -m64
 else
     ifeq ($(IRAFARCH),macosx)
-        CFLAGS_COMMON = -DNDEBUG -arch i386 -m32 -mmacosx-version-min=10.4
+        CFLAGS_COMMON = -DNDEBUG -m32
         LADD += -m32 -arch i386
     endif
 endif

--- a/vendor/voclient/libvo/Makefile
+++ b/vendor/voclient/libvo/Makefile
@@ -28,7 +28,7 @@ CC              = gcc
 CINCS           = -I$(INCDIR)  -I.
 
 CLIBS		= -lm -lc -lcurl -lpthread
-CARCH		= -m64 -mmacosx-version-min=10.5
+CARCH		= -m64
 
 CFLAGS 		= -g -Wall $(CARCH) -D$(PLATFORM) $(CINCS) -L./
 

--- a/vendor/voclient/libvoclient/Makefile
+++ b/vendor/voclient/libvoclient/Makefile
@@ -35,15 +35,15 @@ CC        = gcc
 CINCS     = -I$(HERE)
 ifeq ($(PLATFORM),Darwin)
     ifeq ($(PLMACH),x86_64)
-        CARCH   = -m64 -mmacosx-version-min=10.5
+        CARCH   = -m64
     else
-        CARCH   = -arch i386 -m32 -mmacosx-version-min=10.4
+        CARCH   = -m32
     endif
     ifdef IRAFARCH
         ifeq ($(IRAFARCH),macintel)
-            CARCH = -m64 -mmacosx-version-min=10.5
+            CARCH = -m64
         else
-            CARCH = -arch i386 -m32 -mmacosx-version-min=10.5
+            CARCH = -m32
         endif
     endif
 else

--- a/vendor/voclient/libvotable/Makefile
+++ b/vendor/voclient/libvotable/Makefile
@@ -28,15 +28,15 @@ CC 	  	= gcc
 CINCS  	  	= -I$(INCDIR)  -I. -I../../../include
 ifeq ($(PLATFORM),Darwin)
     ifeq ($(PLMACH),x86_64)
-	CARCH	= -m64 -mmacosx-version-min=10.5
+	CARCH	= -m64
     else
-	CARCH	= -arch i386 -m32 -mmacosx-version-min=10.4
+	CARCH	= -m32
     endif
     ifdef IRAFARCH
         ifeq ($(IRAFARCH),macintel)
-	    CARCH = -m64 -mmacosx-version-min=10.5
+	    CARCH = -m64
         else
-	    CARCH = -arch i386 -m32 -mmacosx-version-min=10.5
+	    CARCH = -m32
 	endif
     endif
 else

--- a/vendor/voclient/voapps/Makefile
+++ b/vendor/voclient/voapps/Makefile
@@ -46,15 +46,15 @@ LIBCFITSIO	= ../lib/libcfitsio.a
         
 ifeq ($(PLATFORM),Darwin)
     ifeq ($(PLMACH),x86_64)
-        CARCH   = -m64 -mmacosx-version-min=10.5
+        CARCH   = -m64
     else
-        CARCH   = -arch i386 -m32 -mmacosx-version-min=10.4
+        CARCH   = -m32
     endif
     ifdef IRAFARCH
         ifeq ($(IRAFARCH),macintel)
-            CARCH = -m64 -mmacosx-version-min=10.5
+            CARCH = -m64
         else
-            CARCH = -arch i386 -m32 -mmacosx-version-min=10.5
+            CARCH = -m32
         endif
     endif
 else

--- a/vendor/voclient/voapps/lib/Makefile
+++ b/vendor/voclient/voapps/lib/Makefile
@@ -34,15 +34,15 @@ CINCS  	    = -I$(HERE) -I../ -I../../include -I../../../../include -L../../lib/
 
 ifeq ($(PLATFORM),Darwin)
     ifeq  ($(PLMACH),x86_64)
-        CARCH   = -m64 -mmacosx-version-min=10.5
+        CARCH   = -m64
     else
-        CARCH   = -arch i386 -m32 -mmacosx-version-min=10.4
+        CARCH   = -m32
     endif
     ifdef IRAFARCH
         ifeq ($(IRAFARCH),macintel)
-            CARCH = -m64 -mmacosx-version-min=10.5
+            CARCH = -m64
         else
-            CARCH = -arch i386 -m32 -mmacosx-version-min=10.5
+            CARCH = -m32
         endif
     endif
 else

--- a/vendor/voclient/voapps/task/Makefile
+++ b/vendor/voclient/voapps/task/Makefile
@@ -33,10 +33,9 @@ CINCS           = -I$(INCDIR)  -I.
 
 ifeq ($(PLATFORM),Darwin)
     ifeq  ($(PLMACH),x86_64)
-        CARCH   = -m64 -mmacosx-version-min=10.5
+        CARCH   = -m64
     else
-        #CARCH   = -arch i386 -arch ppc -m32 -mmacosx-version-min=10.4
-        CARCH   = -mmacosx-version-min=10.4
+        CARCH   = -m32
     endif
     PYFLAGS 	= -dynamiclib -I/usr/include/python$(PYVER)/ -lpython$(PYVER)
 else


### PR DESCRIPTION
The minimal version can now be controlled centrally with the environment variable `MACOSX_DEPLOYMENT_TARGET`, which is now in `irafuser.sh` and `irafuser.csh`.

As always, this is [tested](https://travis-ci.org/olebole/iraf-v216/builds/239945729) (in combination with the other PRs) on several versions of MacOSX, both 32 and 64 bit (and also on Linux, to ensure there are no side effects). The environment variable `MACOSX_DEPLOYMENT_TARGET` exists since [Mac OS X 10.2](https://opensource.apple.com/source/cctools/cctools-822/RelNotes/CompilerTools.html).

Note that this PR touches a number of files that are also changed in other PRs, so there are conflicts to be resolved. a2cf00f934 is a version that works after the other PRs are applied.