### PR TITLE
Port IRAF to several architectures 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,8 @@ linux::
 	(util/mkarch linux)
 linux64::
 	(util/mkarch linux64)
+linuxarm::
+	(util/mkarch linuxarm)
 freebsd::
 	(util/mkarch freebsd)
 cygwin::

--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,8 @@ linux64::
 	(util/mkarch linux64)
 linuxarm::
 	(util/mkarch linuxarm)
+linuxarm64::
+	(util/mkarch linuxarm64)
 freebsd::
 	(util/mkarch freebsd)
 cygwin::

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,8 @@ linuxarm::
 	(util/mkarch linuxarm)
 linuxarm64::
 	(util/mkarch linuxarm64)
+linuxmips::
+	(util/mkarch linuxmips)
 freebsd::
 	(util/mkarch freebsd)
 cygwin::

--- a/unix/as.freebsd/zsvjmp.s
+++ b/unix/as.freebsd/zsvjmp.s
@@ -1,0 +1,46 @@
+	.file	"zsvjmp.s"
+
+# ZSVJMP, ZDOJMP -- Set up a jump (non-local goto) by saving the processor
+# registers in the buffer jmpbuf.  A subsequent call to ZDOJMP restores
+# the registers, effecting a call in the context of the procedure which
+# originally called ZSVJMP, but with the new status code.  These are Fortran
+# callable procedures.
+#
+#		zsvjmp (jmp_buf, status)	# (returns status)
+#		zdojmp (jmp_buf, status)	# (passes status to zsvjmp)
+#
+# These routines are directly comparable to the UNIX setjmp/longjmp, except
+# that they are Fortran callable kernel routines, i.e., trailing underscore,
+# call by reference, and no function returns.  ZSVJMP requires an assembler
+# jacket routine to avoid modifying the call stack, but relies upon setjmp
+# to do the real work.  ZDOJMP is implemented as a portable C routine in OS,
+# calling longjmp to do the restore.  In these routines, JMP_BUF consists
+# of one longword containing the address of the STATUS variable, followed
+# by the "jmp_buf" used by setjmp/longjmp.
+#
+# This file contains the SUN/UNIX 386i (80386) version of ZSVJMP.
+ 
+        .globl	zsvjmp_
+
+	# The following has nothing to do with ZSVJMP, and is included here
+	# only because this assembler module is loaded with every process.
+	# This code sets the value of the symbol MEM (the VOS or Fortran Mem
+	# common) to zero, setting the origin for IRAF pointers to zero
+	# rather than some arbitrary value, and ensuring that the MEM common
+	# is aligned for all datatypes as well as page aligned.  A further
+	# advantage is that references to NULL pointers are likely to cause a
+	# memory violation.
+
+	.globl	mem_
+	mem_	=	0
+
+	.text
+zsvjmp_:
+	movl	4(%esp), %ecx		# &jmpbuf to ECX
+	movl	8(%esp), %eax		# &status to EAX
+	movl	%eax, (%ecx)		# store &status in jmpbuf[0]
+	movl 	$0, (%eax)		# zero the value of status
+	addl	$4, %ecx		# change stack to point to &jmpbuf[1]
+	movl	%ecx, 4(%esp)		# 	...
+	movl	$0, 8(%esp)		# change arg2 to zero
+	jmp	sigsetjmp		# let sigsetjmp do the rest

--- a/unix/as.freebsd64/zsvjmp.s
+++ b/unix/as.freebsd64/zsvjmp.s
@@ -1,0 +1,43 @@
+	.file	"zsvjmp.s"
+
+# ZSVJMP, ZDOJMP -- Set up a jump (non-local goto) by saving the processor
+# registers in the buffer jmpbuf.  A subsequent call to ZDOJMP restores
+# the registers, effecting a call in the context of the procedure which
+# originally called ZSVJMP, but with the new status code.  These are Fortran
+# callable procedures.
+#
+#		zsvjmp (jmp_buf, status)	# (returns status)
+#		zdojmp (jmp_buf, status)	# (passes status to zsvjmp)
+#
+# These routines are directly comparable to the UNIX setjmp/longjmp, except
+# that they are Fortran callable kernel routines, i.e., trailing underscore,
+# call by reference, and no function returns.  ZSVJMP requires an assembler
+# jacket routine to avoid modifying the call stack, but relies upon setjmp
+# to do the real work.  ZDOJMP is implemented as a portable C routine in OS,
+# calling longjmp to do the restore.  In these routines, JMP_BUF consists
+# of one longword containing the address of the STATUS variable, followed
+# by the "jmp_buf" used by setjmp/longjmp.
+#
+ 
+        .globl	zsvjmp_
+	.type   zsvjmp_, @function
+
+	# The following has nothing to do with ZSVJMP, and is included here
+	# only because this assembler module is loaded with every process.
+	# This code sets the value of the symbol MEM (the VOS or Fortran Mem
+	# common) to zero, setting the origin for IRAF pointers to zero
+	# rather than some arbitrary value, and ensuring that the MEM common
+	# is aligned for all datatypes as well as page aligned.  A further
+	# advantage is that references to NULL pointers are likely to cause a
+	# memory violation.
+
+	.globl  _mem_
+	_mem_   =       0
+
+zsvjmp_:
+	# %rsi ... &status  %rdi ... &jumpbuf
+	movq    %rsi, (%rdi)    # store &status in jmpbuf[0]
+	movl    $0, (%rsi)      # zero the value of status
+	addq    $8, %rdi        # change point to &jmpbuf[1]
+	movl    $0, %esi        # change arg2 to zero
+	jmp     sigsetjmp       # let sigsetjmp do the rest

--- a/unix/as.hurd/zsvjmp.s
+++ b/unix/as.hurd/zsvjmp.s
@@ -1,0 +1,46 @@
+	.file	"zsvjmp.s"
+
+# ZSVJMP, ZDOJMP -- Set up a jump (non-local goto) by saving the processor
+# registers in the buffer jmpbuf.  A subsequent call to ZDOJMP restores
+# the registers, effecting a call in the context of the procedure which
+# originally called ZSVJMP, but with the new status code.  These are Fortran
+# callable procedures.
+#
+#		zsvjmp (jmp_buf, status)	# (returns status)
+#		zdojmp (jmp_buf, status)	# (passes status to zsvjmp)
+#
+# These routines are directly comparable to the UNIX setjmp/longjmp, except
+# that they are Fortran callable kernel routines, i.e., trailing underscore,
+# call by reference, and no function returns.  ZSVJMP requires an assembler
+# jacket routine to avoid modifying the call stack, but relies upon setjmp
+# to do the real work.  ZDOJMP is implemented as a portable C routine in OS,
+# calling longjmp to do the restore.  In these routines, JMP_BUF consists
+# of one longword containing the address of the STATUS variable, followed
+# by the "jmp_buf" used by setjmp/longjmp.
+#
+# This file contains the SUN/UNIX 386i (80386) version of ZSVJMP.
+ 
+        .globl	zsvjmp_
+
+	# The following has nothing to do with ZSVJMP, and is included here
+	# only because this assembler module is loaded with every process.
+	# This code sets the value of the symbol MEM (the VOS or Fortran Mem
+	# common) to zero, setting the origin for IRAF pointers to zero
+	# rather than some arbitrary value, and ensuring that the MEM common
+	# is aligned for all datatypes as well as page aligned.  A further
+	# advantage is that references to NULL pointers are likely to cause a
+	# memory violation.
+
+	.globl	mem_
+	mem_	=	0
+
+	.text
+zsvjmp_:
+	movl	4(%esp), %ecx		# &jmpbuf to ECX
+	movl	8(%esp), %eax		# &status to EAX
+	movl	%eax, (%ecx)		# store &status in jmpbuf[0]
+	movl 	$0, (%eax)		# zero the value of status
+	addl	$4, %ecx		# change stack to point to &jmpbuf[1]
+	movl	%ecx, 4(%esp)		# 	...
+	movl	$0, 8(%esp)		# change arg2 to zero
+	jmp	__sigsetjmp		# let sigsetjmp do the rest

--- a/unix/as.linuxarm/zsvjmp.s
+++ b/unix/as.linuxarm/zsvjmp.s
@@ -1,0 +1,18 @@
+	.file	"zsvjmp.s"
+
+@ Copyright (c) 2014 Ole Streicher <debian@liska.ath.cx>
+@ Distributable under the same license as IRAF
+@ This file contains the Linux armel/armhf version of ZSVJMP for Debian.
+
+	.arch armv6
+	.text
+	.global	zsvjmp_
+	.type	zsvjmp_, %function
+
+zsvjmp_:
+	mov	r2, #0         @
+	str	r2, [r1, #0]   @ *status = 0
+	str	r1, [r0, #0]   @ buf[0] = status
+	add	r0, r0, #4     @ &buf[1] --> 1st arg for sigsetjmp
+	mov	r1, #0         @ 0       --> 2nd arg for sigsetjmp
+	b	__sigsetjmp    @ call sigsetjmp

--- a/unix/as.linuxarm64/zsvjmp.s
+++ b/unix/as.linuxarm64/zsvjmp.s
@@ -1,0 +1,17 @@
+	.file	"zsvjmp.s"
+
+	// Copyright (c) 2018 Peter Green
+	// Distributable under the same license as IRAF
+	// This file contains the Linux arm64 version of ZSVJMP for Debian.
+
+	.arch armv8-a
+	.text
+	.global	zsvjmp_
+	.type	zsvjmp_, %function
+
+zsvjmp_:
+        str     xzr, [x1]	// *status = 0;
+        str     x1, [x0], 8	// ((long **)buf)[0] = status
+	// also post-increment x0 by 8: 1st arg for sigsetjmp
+        mov     w1, 0		// 0 --> 2nd arg for sigsetjmp
+        b      __sigsetjmp	// call sigsetjmp

--- a/unix/as.linuxmips/zsvjmp.s
+++ b/unix/as.linuxmips/zsvjmp.s
@@ -1,0 +1,28 @@
+	.file	"zsvjmp.s"
+
+# Copyright (c) 2014 David Kuehling <dvdkhlng AT posteo TOD de>
+# Distributable under the same license as IRAF
+# This file contains the Linux mipsel version of ZSVJMP for Debian.
+
+	.set mips1
+	.abicalls
+	.text
+	.global	zsvjmp_
+	.ent zsvjmp_
+	.type	zsvjmp_, %function
+
+zsvjmp_:
+	.set noreorder
+	.cpload $t9
+	.set reorder
+	sw  $a1, 0($a0)		# buf[0]=status
+	sw  $zero, 0($a1)	# *status=0
+	addiu  $a0, $a0, 4	# &buf[1] --> 1st arg for sigsetjmp
+	move    $a1, $zero	# 2nd arg is zero
+
+	# this call sequence is required when used inside shared library
+	la $t9, __sigsetjmp
+	j $t9
+	##  note: no delay slot, filled by GAS
+
+	.end 	zsvjmp_

--- a/unix/as.linuxmips64/zsvjmp.S
+++ b/unix/as.linuxmips64/zsvjmp.S
@@ -1,0 +1,26 @@
+#include <sys/asm.h>
+#include <sys/regdef.h>
+
+/*
+ * Copyright (c) 2018 James Cowgill <jcowgill AT debian TOD org>
+ * Distributable under the same license as IRAF
+ */
+
+	.file	"zsvjmp.s"
+	.text
+
+LEAF(zsvjmp_)
+	SETUP_GP			/* Load gp (needed for PTR_LA) */
+	SETUP_GP64(v0, zsvjmp_)
+
+	PTR_S a1, 0(a0)			/* buf[0] = status */
+	LONG_S zero, 0(a1)		/* *status = 0 */
+	PTR_ADDIU a0, a0, PTRSIZE	/* a0 = &buf[1], 1st arg for sigsetjmp */
+	move a1, zero			/* a1 = 0, 2nd arg */
+
+	PTR_LA t9, __sigsetjmp		/* t9 = address of sigsetjmp */
+	RESTORE_GP64			/* Restore gp */
+	jr t9				/* Tail call sigsetjmp */
+END(zsvjmp_)
+
+	.section .note.GNU-stack,"",@progbits

--- a/unix/as.linuxppc64/zsvjmp.s
+++ b/unix/as.linuxppc64/zsvjmp.s
@@ -1,0 +1,48 @@
+
+# Copyright 2018 Gustavo Romero, Rogerio Cardoso, Breno Leitao, IBM Corporation.
+
+	.file "zsvjmp.s"
+	.abiversion 2
+	.section ".text"
+	.align 2
+	.globl zsvjmp_
+	.type zsvjmp_, @function
+
+
+# Use VRSAVE (unused in Linux) and stack reserved area (SP+12) to save the
+# return address (LR) which is lost after bl __sigsetjmp. External functions
+# should be called using a 'bl/nop' pair, which is turned into a plt_call stub
+# by the linker. PPC64 does not support 'b' function@plt anymore.
+
+zsvjmp_:
+	# r3 = buf, r4 = &status
+
+	xor   %r11, %r11, %r11  # zero r11
+	std   %r11, 0(%r4)      # *status = 0
+	std   %r4,  0(%r3)      # *(buf + 0) = status
+	addi  %r3, %r3, 8       # r3 = buf + 8
+	mr    %r4, %r11         # r4 = 0
+
+	mflr  %r11              # save LR
+	mtvrsave %r11           # LR LSB to VRSAVE
+	srdi %r11, %r11, 32     # LR MSB to SP+12 (reserved)
+	stw  %r11, 12(%r1)
+
+	bl    __sigsetjmp
+	nop
+
+	lwz %r11, 12(%r1)       # restore LR
+	sldi %r11, %r11, 32
+	mfvrsave %r10
+	add %r11, %r11, %r10
+	mtlr %r11
+
+	# Some libc can use VRSAVE as a boolean to simplify handling VMX
+	# regset save/restore so it's necessary to restore it back to -1
+	# (VRSAVE value is always 0xffffffff).
+	li %r11, -1             # restore VRSAVE
+	mtvrsave %r11
+
+	blr
+	.size	zsvjmp_,.-zsvjmp_
+	.section	.note.GNU-stack,"",@progbits

--- a/unix/as.linuxs390x/zsvjmp.s
+++ b/unix/as.linuxs390x/zsvjmp.s
@@ -1,0 +1,23 @@
+	.file	"zsvjmp.s"
+
+# Set the address of the MEM common to zero.
+	.globl   mem_
+	mem_ = 0
+
+# Copyright (c) 2014 John Long <codeblue@inbox.lv>
+# Distributable under the same license as IRAF
+# This file contains the Linux s390x (64 bit) version of ZSVJMP for Debian.
+
+	.text
+	.global	zsvjmp_
+	.type	zsvjmp_, %function
+
+zsvjmp_:
+        stg     %r3,0(0,%r2)         # save contents of r3 where r2 is pointing
+	xc      0(8,%r3),0(%r3)      # clear doubleword where r3 is pointing
+	xgr     %r3,%r3              # clear r3
+	aghi    %r2,8                # r2 <- r2 + 8
+	jg      __sigsetjmp@PLT      # load vcon resolved by linker
+
+	.size	zsvjmp_, .-zsvjmp_
+	.section	.note.GNU-stack,"",@progbits

--- a/unix/as.macppc/zsvjmp.s
+++ b/unix/as.macppc/zsvjmp.s
@@ -1,0 +1,47 @@
+# ZSVJMP.S -- MacOS X version, September 2001, March 2002.
+
+.file	 "zsvjmp.s"
+
+	# ZSVJMP -- SPP callable SETJMP.
+.text
+	.align	2
+	.globl	_zsvjmp_
+_zsvjmp_:
+	# R3 = buf, R4 = &status
+	li	r11,0			; r11 = 0
+	stw	r11,0(r4)		; set *status to zero
+	stw	r4,0(r3)		; store &status in buf[0]
+	addi	r3,r3,4			; reference buf[1] for setjmp
+	b	L_setjmp$stub
+L2:
+	lwz	r1,0(r1)
+	lwz	r0,8(r1)
+	mtlr	r0
+	lmw	r30,-8(r1)
+	blr
+
+	# The setjmp code is only available in a dynamic library on 10.1.
+.picsymbol_stub
+L_setjmp$stub:
+        .indirect_symbol _setjmp
+        mflr	r0
+        bcl	20,31,L1$pb
+L1$pb:
+        mflr	r11
+        addis	r11,r11,ha16(L1$lz-L1$pb)
+        mtlr	r0
+        lwz	r12,lo16(L1$lz-L1$pb)(r11)
+        mtctr	r12
+        addi	r11,r11,lo16(L1$lz-L1$pb)
+        bctr
+.lazy_symbol_pointer
+L1$lz:
+        .indirect_symbol _setjmp
+        .long dyld_stub_binding_helper
+.text
+.Lfe1:
+
+	# Set the address of the MEM common to zero.
+	.globl   _mem_
+	_mem_ = 0
+

--- a/unix/boot/spp/xc.c
+++ b/unix/boot/spp/xc.c
@@ -40,7 +40,7 @@
 #define	SZ_PKGENV	256
 #define DEF_PKGENV	"iraf"
 
-#ifdef __APPLE__
+#if (defined (__APPLE__) || defined (__freebsd__))
 #define	CCOMP		"cc"			/* C compiler (also .s etc.) */
 #define	LINKER		"cc"			/* Linking utility */
 #define	F_STATIC	"-static"
@@ -78,7 +78,7 @@ char *fortlib[] = { "-lf2c",			/*  0  (host progs) */
 		    "-lm",			/*  2  */
 		    "-lcurl",			/*  3  */
 		    "-lexpat",			/*  4  */
-#ifdef __linux__
+#if (defined (__linux__) || defined (__gnu_hurd__))
 		    "-lpthread",		/*  5  */
 #else
 		    "",				/*  5  */

--- a/unix/f2c/libf2c/uninit.c
+++ b/unix/f2c/libf2c/uninit.c
@@ -178,7 +178,8 @@ ieee0(Void)
 	}
 #endif /* MSpc */
 
-#ifdef __mips	/* must link with -lfpe */
+/* What follows is for SGI IRIX only */
+#if defined(__mips) && defined(__sgi)   /* must link with -lfpe */
 #define IEEE0_done
 /* code from Eric Grosse */
 #include <stdlib.h>
@@ -231,7 +232,36 @@ ieee0(Void)
 	}
 #endif /* mips */
 
-#ifdef __linux__
+/*
+ * The following is the preferred method but depends upon a GLIBC extension only
+ * to be found in GLIBC 2.2 or later.  It is a GNU extension, not included in the
+ * C99 extensions which allow the FP status register to be examined in a platform
+ * independent way.  It should be used if at all possible  -- AFRB
+ */
+
+
+#if (defined(__GLIBC__)&& ( __GLIBC__>=2) && (__GLIBC_MINOR__>=2) )
+#define _GNU_SOURCE 1
+#define IEEE0_done
+#include <fenv.h>
+ static void
+  ieee0(Void)
+        
+{
+    /* Clear all exception flags */
+    if (fedisableexcept(FE_ALL_EXCEPT)==-1)
+         unsupported_error();
+    if (feenableexcept(FE_DIVBYZERO|FE_INVALID|FE_OVERFLOW)==-1)
+         unsupported_error();
+}
+
+#endif /* Glibc control */
+
+/* Many linux cases will be treated through GLIBC.  Note that modern
+ * linux runs on many non-i86 plaforms and as a result the following code
+ * must be processor dependent rather than simply OS specific */
+ 
+#if (defined(__linux__)&&(!defined(IEEE0_done)))
 #define IEEE0_done
 #include "fpu_control.h"
 

--- a/unix/hlib/iraf32.h
+++ b/unix/hlib/iraf32.h
@@ -61,16 +61,6 @@ define	SZ_PATHNAME	511		# OS dependent file names
 define	SZ_LINE		1023		# max chars in a line
 define	SZ_COMMAND	2047		# max size command block
 
-define  SZ_MII_SHORT    1		# size of MII data in SPP chars
-define  SZ_MII_LONG     2
-define  SZ_MII_REAL     2
-define  SZ_MII_DOUBLE   4
-define  SZ_MII_INT      SZ_MII_LONG
-
-define	SZ_INT32	2		# FIXED -- Do not change!
-define	SZ_LONG32	2
-define	SZ_STRUCT32	2
-
 define	TY_BOOL		1		# codes for type arguments, sizeof
 define	TY_CHAR		2
 define	TY_SHORT	3
@@ -83,6 +73,16 @@ define	TY_POINTER	9
 define	TY_STRUCT	10		# last (regular) type code
 define	TY_USHORT	11		# for image i/o
 define	TY_UBYTE	12		# (special) for image i/o
+
+define  SZ_MII_SHORT    1		# size of MII data in SPP chars
+define  SZ_MII_LONG     2
+define  SZ_MII_REAL     2
+define  SZ_MII_DOUBLE   4
+define  SZ_MII_INT      SZ_MII_LONG
+
+define	SZ_INT32	2		# FIXED -- Do not change!
+define	SZ_LONG32	2
+define	SZ_STRUCT32	2
 
 # Indefinite values.
 define	INDEFS		(-32767)

--- a/unix/hlib/iraf64.h
+++ b/unix/hlib/iraf64.h
@@ -87,7 +87,6 @@ define	SZ_STRUCT32	2
 # Indefinite values.
 define	INDEFS		(-32767)
 define	INDEFL		(-2147483647)
-#define	INDEFL		(-9223372036854775807)
 define	INDEFI		INDEFL
 define	INDEFR		1.6e38
 define	INDEFD		1.6d308

--- a/unix/hlib/irafarch.sh
+++ b/unix/hlib/irafarch.sh
@@ -156,7 +156,7 @@ case "$MNAME" in
 	pipes=0
         ;;
 
-    "redhat"|"linux"|"linux64"|"linuxs390x")
+    "redhat"|"linux"|"linux64"|"linuxs390x"|"linuxarm")
         if [ -n "$IRAFARCH" ]; then
             mach="$IRAFARCH"
             hmach="$IRAFARCH"
@@ -175,6 +175,10 @@ case "$MNAME" in
                 mach="linuxs390x"
                 hmach="linuxs390x"
 	        nbits=64
+		endian="big"
+            elif [ "$MNAME_M" = "armhf" -o "$MNAME_M" = "armv7l" ]; then
+                mach="linuxarm"
+                hmach="linuxarm"
             else					# Linux
                 mach="linux"
                 hmach="linux"

--- a/unix/hlib/irafarch.sh
+++ b/unix/hlib/irafarch.sh
@@ -156,7 +156,7 @@ case "$MNAME" in
 	pipes=0
         ;;
 
-    "redhat"|"linux"|"linux64"|"linuxs390x"|"linuxarm")
+    "redhat"|"linux"|"linux64"|"linuxs390x"|"linuxarm"|"linuxarm64")
         if [ -n "$IRAFARCH" ]; then
             mach="$IRAFARCH"
             hmach="$IRAFARCH"
@@ -179,6 +179,10 @@ case "$MNAME" in
             elif [ "$MNAME_M" = "armhf" -o "$MNAME_M" = "armv7l" ]; then
                 mach="linuxarm"
                 hmach="linuxarm"
+            elif [ "$MNAME_M" = "aarch64" ]; then
+                mach="linuxarm64"
+                hmach="linuxarm64"
+                nbits=64
             else					# Linux
                 mach="linux"
                 hmach="linux"

--- a/unix/hlib/irafarch.sh
+++ b/unix/hlib/irafarch.sh
@@ -4,11 +4,12 @@
 #
 #  Usage:       irafarch
 #		irafarch -set [<arch>] [opts]
-#               irafarch [ -hsi | -nbits | -pipe | -tapecap | -tape ]
+#               irafarch [ -hsi | -nbits | -endian | -pipe | -tapecap | -tape ]
 #
 #	-mach		print the iraf architecture name [default]
 #	-hsi		print the HSI arch
 #	-nbits		print number of bits in an int (32 or 64)
+#	-endian		print endianness of platform (big or little)
 #	-pipe		does platform support display fifo pipes?
 #	-tapecap	does platform require tapecap changes?
 #	-tape		does platform support tape drives?
@@ -26,6 +27,7 @@
 
 hmach="INDEF"
 nbits=32
+endian="little"
 pipes=1
 shlibs=0
 tapecaps=0
@@ -104,6 +106,7 @@ fi
 # Set some common defaults for most platforms
 shlib=0				# no shared lib support
 nbits=32			# 32-bit architecture
+endian="little"
 tapecaps=1			# platform supports tapecaps
 tapes=1				# platform support tape drives
 pipes=1				# supports display fifo pipes
@@ -142,7 +145,6 @@ case "$MNAME" in
             else
                 mach="ipad"				# iOS Device
                 hmach="ipad"
-		nbits=32
             fi
 	fi
 	tapecaps=0
@@ -157,6 +159,9 @@ case "$MNAME" in
 	    if [ "$mach" == "linux64" ]; then
 		nbits=64
 	    fi
+	    if [ "$mach" == "linuxs390x" ]; then
+		endian="big"
+	    fi
 	else 
             if [ "$MNAME_M" == "x86_64" ]; then		# Linux x86_64
                 mach="linux64"
@@ -165,7 +170,6 @@ case "$MNAME" in
             else					# Linux
                 mach="linux"
                 hmach="linux"
-	        nbits=32
             fi
         fi
         ;;
@@ -240,6 +244,9 @@ else
 	;;
     "-nbits")
 	ECHO $nbits
+	;;
+    "-endian")
+	ECHO $endian
 	;;
     "-pipes")
 	ECHO $pipes

--- a/unix/hlib/irafarch.sh
+++ b/unix/hlib/irafarch.sh
@@ -126,7 +126,7 @@ fi
 
 # Determine parameters for each architecture.
 case "$MNAME" in
-     "darwin"|"ipad"|"macosx"|"macintel")		# Mac OS X
+     "darwin"|"ipad"|"macosx"|"macintel"|"macppc")		# Mac OS X
         if [ -n "$IRAFARCH" ]; then
             mach="$IRAFARCH"
             hmach="$IRAFARCH"
@@ -141,6 +141,10 @@ case "$MNAME" in
             elif [ "$MNAME_M" == "x86" -o "$MNAME_M" == "i386" ]; then
                 mach="macosx"
                 hmach="macosx"
+		nbits=32
+            elif [ "$MNAME_M" == "power_macintosh" -o "$MNAME_M" == "ppc" ]; then
+                mach="macppc"
+                hmach="macppc"
 		nbits=32
             else
                 mach="ipad"				# iOS Device

--- a/unix/hlib/irafarch.sh
+++ b/unix/hlib/irafarch.sh
@@ -156,22 +156,22 @@ case "$MNAME" in
 	pipes=0
         ;;
 
-    "redhat"|"linux"|"linux64"|"linuxs390x"|"linuxarm"|"linuxarm64"|"linuxmips")
+    "redhat"|"linux"|"linux64"|"linuxs390x"|"linuxarm"|"linuxarm64"|"linuxmips"|"linuxmips64")
         if [ -n "$IRAFARCH" ]; then
             mach="$IRAFARCH"
             hmach="$IRAFARCH"
-	    if [ "$mach" == "linux64" -o "$mach" == "linuxs390x" ]; then
+	    if [ "$mach" = "linux64" -o "$mach" = "linuxs390x" -o "$mach" = "linuxarm64" -o "$mach" = "linuxmips64" ]; then
 		nbits=64
 	    fi
-	    if [ "$mach" == "linuxs390x" ]; then
+	    if [ "$mach" = "linuxs390x" ]; then
 		endian="big"
 	    fi
 	else 
-            if [ "$MNAME_M" == "x86_64" ]; then		# Linux x86_64
+            if [ "$MNAME_M" = "x86_64" ]; then		# Linux x86_64
                 mach="linux64"
                 hmach="linux64"
 	        nbits=64
-            elif [ "$MNAME_M" == "s390x" ]; then
+            elif [ "$MNAME_M" = "s390x" ]; then
                 mach="linuxs390x"
                 hmach="linuxs390x"
 	        nbits=64
@@ -186,6 +186,10 @@ case "$MNAME" in
             elif [ "$MNAME_M" = "mips" ]; then
                 mach="linuxmips"
                 hmach="linuxmips"
+            elif [ "$MNAME_M" = "mips64" ]; then
+                mach="linuxmips64"
+                hmach="linuxmips64"
+                nbits=64
             else					# Linux
                 mach="linux"
                 hmach="linux"

--- a/unix/hlib/irafarch.sh
+++ b/unix/hlib/irafarch.sh
@@ -195,9 +195,31 @@ case "$MNAME" in
         fi
         ;;
 
-    "freebsd") 					# FreeBSD
-        mach="freebsd"
-        hmach="freebsd"
+    "freebsd"|"freebsd64") 					# FreeBSD
+        if [ -n "$IRAFARCH" ]; then
+            mach="$IRAFARCH"
+            hmach="$IRAFARCH"
+	    if [ "$mach" == "freebsd64" ]; then
+		nbits=64
+	    fi
+	else 
+            if [ "$MNAME_M" == "amd64" ]; then		# Linux x86_64
+                mach="freebsd64"
+                hmach="freebsd64"
+	        nbits=64
+            else					# Linux
+                mach="freebsd"
+                hmach="freebsd"
+	        nbits=32
+            fi
+        fi
+	tapecaps=0
+	tapes=0
+	pipes=0
+        ;;
+    "gnu"|"hurd") # GNU HURD
+        mach="hurd"
+        hmach="hurd"
 	tapecaps=0
 	tapes=0
 	pipes=0

--- a/unix/hlib/irafarch.sh
+++ b/unix/hlib/irafarch.sh
@@ -156,11 +156,11 @@ case "$MNAME" in
 	pipes=0
         ;;
 
-    "redhat"|"linux"|"linux64"|"linuxs390x"|"linuxarm"|"linuxarm64"|"linuxmips"|"linuxmips64")
+    "redhat"|"linux"|"linux64"|"linuxs390x"|"linuxarm"|"linuxarm64"|"linuxmips"|"linuxmips64"|"linuxppc64")
         if [ -n "$IRAFARCH" ]; then
             mach="$IRAFARCH"
             hmach="$IRAFARCH"
-	    if [ "$mach" = "linux64" -o "$mach" = "linuxs390x" -o "$mach" = "linuxarm64" -o "$mach" = "linuxmips64" ]; then
+	    if [ "$mach" = "linux64" -o "$mach" = "linuxs390x" -o "$mach" = "linuxarm64" -o "$mach" = "linuxmips64" -o "linuxppc64" ]; then
 		nbits=64
 	    fi
 	    if [ "$mach" = "linuxs390x" ]; then
@@ -190,6 +190,10 @@ case "$MNAME" in
                 mach="linuxmips64"
                 hmach="linuxmips64"
                 nbits=64
+            elif [ "$MNAME_M" = "ppc64le" ]; then
+                mach="linuxppc64"
+                hmach="linuxppc64"
+		nbits=64
             else					# Linux
                 mach="linux"
                 hmach="linux"

--- a/unix/hlib/irafarch.sh
+++ b/unix/hlib/irafarch.sh
@@ -152,11 +152,11 @@ case "$MNAME" in
 	pipes=0
         ;;
 
-    "redhat"|"linux"|"linux64")
+    "redhat"|"linux"|"linux64"|"linuxs390x")
         if [ -n "$IRAFARCH" ]; then
             mach="$IRAFARCH"
             hmach="$IRAFARCH"
-	    if [ "$mach" == "linux64" ]; then
+	    if [ "$mach" == "linux64" -o "$mach" == "linuxs390x" ]; then
 		nbits=64
 	    fi
 	    if [ "$mach" == "linuxs390x" ]; then
@@ -166,6 +166,10 @@ case "$MNAME" in
             if [ "$MNAME_M" == "x86_64" ]; then		# Linux x86_64
                 mach="linux64"
                 hmach="linux64"
+	        nbits=64
+            elif [ "$MNAME_M" == "s390x" ]; then
+                mach="linuxs390x"
+                hmach="linuxs390x"
 	        nbits=64
             else					# Linux
                 mach="linux"

--- a/unix/hlib/irafarch.sh
+++ b/unix/hlib/irafarch.sh
@@ -156,7 +156,7 @@ case "$MNAME" in
 	pipes=0
         ;;
 
-    "redhat"|"linux"|"linux64"|"linuxs390x"|"linuxarm"|"linuxarm64")
+    "redhat"|"linux"|"linux64"|"linuxs390x"|"linuxarm"|"linuxarm64"|"linuxmips")
         if [ -n "$IRAFARCH" ]; then
             mach="$IRAFARCH"
             hmach="$IRAFARCH"
@@ -183,6 +183,9 @@ case "$MNAME" in
                 mach="linuxarm64"
                 hmach="linuxarm64"
                 nbits=64
+            elif [ "$MNAME_M" = "mips" ]; then
+                mach="linuxmips"
+                hmach="linuxmips"
             else					# Linux
                 mach="linux"
                 hmach="linux"

--- a/unix/hlib/mach32.h
+++ b/unix/hlib/mach32.h
@@ -22,13 +22,6 @@ define	NBITS_LONG	32		# nbits in a long
 define	EPSILONR	(1.192e-7)	# smallest E such that 1.0 + E > 1.0
 define	EPSILOND	(2.220d-16)	# double precision epsilon
 define	EPSILON		EPSILONR
-
-# Is byte swapping needed for a 2 or 4 byte MII integer or a 4 or 8 byte
-# IEEE floating to convert to or from MII format on this machine?
-
-define	BYTE_SWAP2	YES
-define	BYTE_SWAP4	YES
-define	BYTE_SWAP8	YES
-define	IEEE_SWAP4	YES
-define	IEEE_SWAP8	YES
 define	IEEE_USED	YES
+
+include <swap.h>

--- a/unix/hlib/mach64.h
+++ b/unix/hlib/mach64.h
@@ -22,13 +22,6 @@ define	NBITS_LONG	64		# nbits in a long
 define	EPSILONR	(1.192e-7)	# smallest E such that 1.0 + E > 1.0
 define	EPSILOND	(2.220d-16)	# double precision epsilon
 define	EPSILON		EPSILONR
-
-# Is byte swapping needed for a 2 or 4 byte MII integer or a 4 or 8 byte
-# IEEE floating to convert to or from MII format on this machine?
-
-define	BYTE_SWAP2	YES
-define	BYTE_SWAP4	YES
-define	BYTE_SWAP8	YES
-define	IEEE_SWAP4	YES
-define	IEEE_SWAP8	YES
 define	IEEE_USED	YES
+
+include <swap.h>

--- a/unix/hlib/swap.h
+++ b/unix/hlib/swap.h
@@ -1,0 +1,1 @@
+swaple.h

--- a/unix/hlib/swapbe.h
+++ b/unix/hlib/swapbe.h
@@ -1,0 +1,9 @@
+# Is byte swapping needed for a 2 or 4 byte MII integer or a 4 or 8 byte
+# IEEE floating to convert to or from MII format on this machine?
+# BIG Endian: NO!
+
+define	BYTE_SWAP2	NO
+define	BYTE_SWAP4	NO
+define	BYTE_SWAP8	NO
+define	IEEE_SWAP4	NO
+define	IEEE_SWAP8	NO

--- a/unix/hlib/swaple.h
+++ b/unix/hlib/swaple.h
@@ -1,0 +1,9 @@
+# Is byte swapping needed for a 2 or 4 byte MII integer or a 4 or 8 byte
+# IEEE floating to convert to or from MII format on this machine?
+# Little Endian: YES!
+
+define	BYTE_SWAP2	YES
+define	BYTE_SWAP4	YES
+define	BYTE_SWAP8	YES
+define	IEEE_SWAP4	YES
+define	IEEE_SWAP8	YES

--- a/unix/os/irafpath.c
+++ b/unix/os/irafpath.c
@@ -79,6 +79,8 @@ char *fname;			/* simple filename, no dirs */
 	strcat (pathname, ".macintel");
 #elif defined (__i386__)
 	strcat (pathname, ".macosx");
+#elif defined (__ppc__)
+	strcat (pathname, ".macppc");
 #endif
 
 #else /* ! __APPLE__ */

--- a/unix/os/irafpath.c
+++ b/unix/os/irafpath.c
@@ -73,22 +73,34 @@ char *fname;			/* simple filename, no dirs */
 	strcpy (pathname, (char *)hostdir);
 	strcat (pathname, "bin");
 
-#ifdef __linux__
-#ifdef __x86_64__
-	strcat (pathname, ".linux64");
-#endif
-#ifdef __i386__
-	strcat (pathname, ".linux");
-#endif
-#endif
-#ifdef __APPLE__
-#ifdef __x86_64__
+#if defined( __APPLE__) /* These have special rules */
+
+#if defined (__x86_64__)
 	strcat (pathname, ".macintel");
-#endif
-#ifdef __i386__
+#elif defined (__i386__)
 	strcat (pathname, ".macosx");
 #endif
+
+#else /* ! __APPLE__ */
+
+#if defined (__linux__)
+	strcat (pathname, ".linux");
+#elif defined( __freebsd__)
+	strcat (pathname, ".freebsd");
+#elif defined( __hurd__)
+	strcat (pathname, ".hurd");
+#else
+	strcat (pathname, ".unknown");
 #endif
+
+#if defined (__i386__)
+	/* append nothing */
+#elif defined (__x86_64__)
+	strcat (pathname, "64");
+#endif
+
+#endif /* ! __APPLE__ */
+
 	strcat (pathname, "/");
 	strcat (pathname, fname);
 	if (access (pathname, 0) == 0)

--- a/unix/os/irafpath.c
+++ b/unix/os/irafpath.c
@@ -111,6 +111,8 @@ char *fname;			/* simple filename, no dirs */
 #else
 	strcat (pathname, "mips");
 #endif
+#elif defined (__ppc64__)
+	strcat (pathname, "ppc64");
 #endif
 
 #endif /* ! __APPLE__ */

--- a/unix/os/irafpath.c
+++ b/unix/os/irafpath.c
@@ -105,6 +105,8 @@ char *fname;			/* simple filename, no dirs */
 	strcat (pathname, "arm");
 #elif defined (__s390x__)
 	strcat (pathname, "s390x");
+#elif defined (__mips__)
+	strcat (pathname, "mips");
 #endif
 
 #endif /* ! __APPLE__ */

--- a/unix/os/irafpath.c
+++ b/unix/os/irafpath.c
@@ -99,6 +99,8 @@ char *fname;			/* simple filename, no dirs */
 	/* append nothing */
 #elif defined (__x86_64__)
 	strcat (pathname, "64");
+#elif defined (__aarch64__)
+	strcat (pathname, "arm64");
 #elif defined (__arm__)
 	strcat (pathname, "arm");
 #elif defined (__s390x__)

--- a/unix/os/irafpath.c
+++ b/unix/os/irafpath.c
@@ -106,7 +106,11 @@ char *fname;			/* simple filename, no dirs */
 #elif defined (__s390x__)
 	strcat (pathname, "s390x");
 #elif defined (__mips__)
+#if (_MIPS_SIM == _ABI64)
+	strcat (pathname, "mips64");
+#else
 	strcat (pathname, "mips");
+#endif
 #endif
 
 #endif /* ! __APPLE__ */

--- a/unix/os/irafpath.c
+++ b/unix/os/irafpath.c
@@ -97,6 +97,8 @@ char *fname;			/* simple filename, no dirs */
 	/* append nothing */
 #elif defined (__x86_64__)
 	strcat (pathname, "64");
+#elif defined (__s390x__)
+	strcat (pathname, "s390x");
 #endif
 
 #endif /* ! __APPLE__ */

--- a/unix/os/irafpath.c
+++ b/unix/os/irafpath.c
@@ -99,6 +99,8 @@ char *fname;			/* simple filename, no dirs */
 	/* append nothing */
 #elif defined (__x86_64__)
 	strcat (pathname, "64");
+#elif defined (__arm__)
+	strcat (pathname, "arm");
 #elif defined (__s390x__)
 	strcat (pathname, "s390x");
 #endif

--- a/util/mkarch
+++ b/util/mkarch
@@ -39,6 +39,7 @@ while [ "$loop_" == "yes" ]; do
   if [ "$#" -gt 0 ]; then
     arch=$1
     nbits=$(IRAFARCH=$arch $iraf/unix/hlib/irafarch.sh -nbits)
+    endian=$(IRAFARCH=$arch $iraf/unix/hlib/irafarch.sh -endian)
 
     if (( "$use_mkpkg"==1 )); then
         mkpkg $arch
@@ -66,6 +67,11 @@ while [ "$loop_" == "yes" ]; do
 	     rm -f iraf.h mach.h; \
 	     ln -s iraf32.h iraf.h; \
 	     ln -s mach32.h mach.h; cd $iraf
+    fi
+    if [ "$endian" = "big" ]; then
+        ( cd unix/hlib; ln -sf swapbe.h swap.h )
+    else
+        ( cd unix/hlib; ln -sf swaple.h swap.h )
     fi
     loop_="no"
 

--- a/util/mkarch
+++ b/util/mkarch
@@ -38,6 +38,7 @@ while [ "$loop_" == "yes" ]; do
 
   if [ "$#" -gt 0 ]; then
     arch=$1
+    nbits=$(IRAFARCH=$arch $iraf/unix/hlib/irafarch.sh -nbits)
 
     if (( "$use_mkpkg"==1 )); then
         mkpkg $arch
@@ -47,6 +48,7 @@ while [ "$loop_" == "yes" ]; do
 	$iraf/util/mkclean
         /bin/rm -rf bin noao/bin unix/bin unix/as vo/bin
 
+        mkdir -p bin.$arch vo/bin.$arch noao/bin.$arch unix/bin.$arch
         ln -s bin.$arch bin
         cd vo; ln -s bin.$arch bin; cd ../
         cd noao; ln -s bin.$arch bin; cd ../
@@ -54,7 +56,7 @@ while [ "$loop_" == "yes" ]; do
         cd unix; ln -s as.$arch as; cd ../
     fi
 
-    if [ "$arch" == "macintel" -o "$arch" == "linux64" ]; then
+    if [ "$nbits" = "64" ]; then
         cd unix/hlib; \
 	     rm -f iraf.h mach.h; \
 	     ln -s iraf64.h iraf.h; \


### PR DESCRIPTION
This PR is used as a proof that the current structure is portable. While the ports are not complete (no documentation, minimal testing), they show that we didn't loose flexibility while cleaning up. The choice is mainly taken to check a wide range of operating systems.

List of ports:

- [x] __FreeBSD intel 64 bit__, `freebsd64` - passes all tests
- [x] __GNU Hurd intel 32 bit__, `hurd` - passes all tests, created as Debian package
- [x] _MacOSX PowerPC 32 bit, `macppc` (needs/includes #3) - see below_
- [x] __Debian Linux arm 32 bit__, `linuxarm` - passes all tests, created as Debian package
- [x] __Debian Linux arm 64 bit__, `linuxarm64` - passes all tests, created as Debian package
- [X] _Debian Linux s390x 64 bit, `linuxs390x` - partly works, but has some problems with endianness (big endian)_
- [x] __Debian Linux MIPS 32 bit little endian__, `linuxmips` - passes all tests, created as Debian package