### PR TITLE
Add -no-pie to linker flags [skip ci]

### DIFF
--- a/unix/hlib/irafuser.sh
+++ b/unix/hlib/irafuser.sh
@@ -25,9 +25,9 @@ export XC_CFLAGS="-I${iraf}include ${CFLAGS} -g -Wall -O2"
 export HSI_CF="${XC_CFLAGS}"
 export HSI_XF="-x -Inolibc -/Wall -/O2"
 export HSI_FF="-g -DBLD_KERNEL -O2"
-export HSI_LF=""
-export HSI_F77LIBS=""
-export HSI_LFLAGS=""
+export HSI_LF="-no-pie"
+export HSI_F77LIBS="-no-pie"
+export HSI_LFLAGS="-no-pie"
 export HSI_OSLIBS=""
 
 if [ "$MACH" = "macosx" -o "$MACH" = "linux" ] ; then

--- a/unix/hlib/mkpkg.inc
+++ b/unix/hlib/mkpkg.inc
@@ -8,7 +8,7 @@ $set	SITEID		= noao		# site name
 
 $set	XFLAGS		= "-c -w"	# default XC compile flags
 $set	XVFLAGS		= "-c -w"	# VOPS XC compile flags
-$set	LFLAGS		= "-Nz"	        # default XC link flags
+$set	LFLAGS		= "-Nz -/no-pie" # default XC link flags
 
 $set	USE_LIBMAIN	= yes		# update lib$libmain.o (root object)
 $set	USE_KNET	= yes		# use the KI (network interface)


### PR DESCRIPTION
See iraf/iraf-v216#103 for a discussion.

[skip ci], since it does not work on the Travis configuration (no support of PIE).