### PR TITLE
Handle negative pointers (indices) in nmemio

### DIFF
--- a/sys/nmemio/coerce.x
+++ b/sys/nmemio/coerce.x
@@ -12,14 +12,21 @@ pointer	p
 include	<szdtype.inc>
 
 begin
-	p = ptr - 1
 	if (type1 == TY_CHAR) {
-	    return (p / ty_size[type2] + 1)
+	    if (ptr > 0) {
+		return ((ptr - 1) / ty_size[type2] + 1)
+	    } else {
+		return (ptr / ty_size[type2])
+	    }
 	} else if (type2 == TY_CHAR) {
-	    return (p * ty_size[type1] + 1)
+	    return ((ptr - 1) * ty_size[type1] + 1)
 	} else {
-	    p = p * ty_size[type1]				# ptr to char
+	    p = (ptr - 1) * ty_size[type1]			# ptr to char
 	    n = ty_size[type2]
-	    return (((p + n-1) / n) + 1)
+	    if (p > 0) {
+		return ((p + n-1) / n + 1)
+	    } else {
+		return (p / n + 1)
+	    }
 	}
 end

--- a/sys/nmemio/mfree.x
+++ b/sys/nmemio/mfree.x
@@ -26,10 +26,6 @@ include "nmemio.com"
 begin
 	# Check for NULL or already-freed pointers.  We only invoke an error 
 	# rather than sys_panic to allow for recovery.
-	if (ptr < 0) {
-	    call merror ("Attempt to free already freed pointer")
-	    return 
-	}
 	if (mdebug > 0 && ptr == NULL) {
 	    call merror ("Attempt to free NULL pointer")
 	    return 
@@ -90,7 +86,6 @@ begin
 	        call mgc_update (ptr)
 	    if (mcollect >= 0)
 	        nfree = nfree + 1
-	    ptr   = - ptr
 	    ptr   = NULL
 	}
 end

--- a/sys/nmemio/mgdptr.x
+++ b/sys/nmemio/mgdptr.x
@@ -23,6 +23,8 @@ begin
 	bufadr = fwa + (5 * SZ_INT)
 
 	modulus = mod (bufadr - fwa_align, sz_align)
+	if (modulus < 0)
+	    modulus = modulus + sz_align
 	if (modulus != 0)
 	    bufadr = bufadr + (sz_align - modulus)
 

--- a/sys/nmemio/minit.x
+++ b/sys/nmemio/minit.x
@@ -44,6 +44,7 @@ begin
 	nleaked	  = 0
 	nalloc	  = 0
 	nfree	  = 0
+	bmax      = 0
 
 	in_task	  = 1
 end

--- a/sys/nmemio/nmemio.com
+++ b/sys/nmemio/nmemio.com
@@ -17,10 +17,11 @@ int 	nfree				# total number of frees
 int	mdebug				# debugging memory use in tasks?
 int	in_task				# in task or iraf main?
 
+int	bmax                            # current maximum number of pointers
 pointer	mgc				# garbage collection buffer
 
 #  Debug common
 common	/nmemio/ mclear, mwatch, mcollect, mreport, lsentinal, usentinal,
 		 mem_used, max_alloc, nleaked, leaked, nalloc, nfree, 
-		 mdebug, in_task, mgc
+		 mdebug, in_task, bmax, mgc
 


### PR DESCRIPTION
Negative pointers may appear when the address of the `Mem` common  block is larger than the handled address. Usually, the address of the `Mem` common block is set to zero in `zsvjmp.s`. However, this is not always the case; f.e. currently this is disabled on the linux64 platform. The big problem for the future here is however the introduction of [Position Independent Executables](https://en.wikipedia.org/wiki/Position-independent_code#PIE), which make such a setting impossible by design.

The sign of the pointers was used as a flag to mark a freed space as such, so that a second attempt to free it will be discovered and properly handled. The sign was also used as a marker in the garbage collector to re-use positions that are already freed. 

This PR uses in both cases NULL as the marker.
The `nmemio` module was checked carefully for other sign dependent behaviour of the pointer.