### PR TITLE
Adjust Integer size for ILP64

### DIFF
--- a/unix/f2c/src/init.c
+++ b/unix/f2c/src/init.c
@@ -79,7 +79,12 @@ int tyint	= TYLONG ;
 int tylogical	= TYLONG;
 int tylog	= TYLOGICAL;
 int typesize[NTYPES] = {
-	1, SZADDR, 1, SZSHORT, SZLONG,
+	1, SZADDR, 1, SZSHORT,
+#if (__SIZEOF_LONG__ == 8 && __SIZEOF_POINTER__ == 8) /* ILP64 */
+	        2*SZLONG,
+#else /* ILP32 */
+	        SZLONG,
+#endif
 #ifdef TYQUAD
 		2*SZLONG,
 #endif


### PR DESCRIPTION
To change the size of `INTEGER` to 64 bit it is __not enough__ to just patch `f2c.h`, also the length of an integer must be adjusted in the f2c sources, since it is f.e. needed to determine the largest type to use in an `EQUIVALENCE` statement. Otherwise, the wrong type may be used there as the general type. This happens f.e. in [`ieeer.x`](https://github.com/iraf/iraf-v216/blob/9590f45760a4791f3305407fb51c87f1282b32be/sys/osb/ieeer.x#L101-L105):

```
int	expon, i, val
real	fval
int	ival[1]
%	equivalence (fval, ival)
%	equivalence (ival, val)
```

translates by the current `f2c.e` to

```
    static real equiv_1[1];

    /* Local variables */
    static integer i__;
#define val ((integer *)equiv_1)
#define fval (equiv_1)
#define ival ((integer *)equiv_1)
```

This is wrong: on ILP64, `real` is a 4-byte floating point, while `integer` is an 8-byte integer. Dereferencing [`ival`](https://github.com/iraf/iraf-v216/blob/9590f45760a4791f3305407fb51c87f1282b32be/sys/osb/ieeer.x#L120) will therefore cause reading memory outside of the definition of `rval`, which is an error and may cause segmentation faults. The reason is that `f2c.e` uses the variable with the largest size for storage, and since in the original f2c code `real` and `integer` are both 4 bytes, it has the freedom to use either of them (and choosed `real`).

This PR changes the size of `INTEGER` to 8 bytes on 64 bit platforms, in conformance with its length specified in `f2c.h`. Then, the definition is properly changed to `integer` on those platforms.