### PR TITLE
Add a trailing `\0` to the end of variable format strings in `pkg/tbtables/fitsio/`

### DIFF
--- a/pkg/tbtables/fitsio/ftc2dd.f
+++ b/pkg/tbtables/fitsio/ftc2dd.f
@@ -20,11 +20,11 @@ C       find length of the input double character string
 
 C       construct the format statement to read the character string
         if (nleng .le. 9)then
-                write(iform,1000)nleng
-1000            format('(F',I1,'.0)')
+                write(iform,1000)nleng, '\0'
+1000            format('(F',I1,'.0)',A)
         else
-                write(iform,1001)nleng
-1001            format('(F',I2,'.0)')
+                write(iform,1001)nleng, '\0'
+1001            format('(F',I2,'.0)',A)
         end if
 
         read(cval,iform,err=900)val

--- a/pkg/tbtables/fitsio/ftc2ii.f
+++ b/pkg/tbtables/fitsio/ftc2ii.f
@@ -17,11 +17,11 @@ C       find length of the input integer character string
 
 C       construct the format statement to read the character string
         if (nleng .le. 9)then
-                write(iform,1000)nleng
-1000            format('(I',I1,')')
+                write(iform,1000)nleng, '\0'
+1000            format('(I',I1,')',A)
         else
-                write(iform,1001)nleng
-1001            format('(I',I2,')')
+                write(iform,1001)nleng, '\0'
+1001            format('(I',I2,')',A)
         end if
 
         read(cval,iform,err=900)ival

--- a/pkg/tbtables/fitsio/ftc2rr.f
+++ b/pkg/tbtables/fitsio/ftc2rr.f
@@ -22,11 +22,11 @@ C       find length of the input real character string
 
 C       construct the format statement to read the character string
         if (nleng .le. 9)then
-                write(iform,1000)nleng
-1000            format('(F',I1,'.0)')
+                write(iform,1000)nleng, '\0'
+1000            format('(F',I1,'.0)',A)
         else
-                write(iform,1001)nleng
-1001            format('(F',I2,'.0)')
+                write(iform,1001)nleng, '\0'
+1001            format('(F',I2,'.0)',A)
         end if
 
         read(cval,iform,err=900)val


### PR DESCRIPTION
f2c does not recognize the length of a variable `FMT` string and will try to read the string until a non-blank appears. An f2c translation of the [FORTRAN statement](https://github.com/iraf/iraf-v216/blob/9590f45760a4791f3305407fb51c87f1282b32be/pkg/tbtables/fitsio/ftc2dd.f#L30) 

```
      read(cval,iform,err=900)val
```
is:

```
    ici__1.icierr = 1;
    ici__1.iciend = 0;
    ici__1.icirnum = 1;
    ici__1.icirlen = cval_len; // <-- length of cval
    ici__1.iciunit = cval;
    ici__1.icifmt = iform;     // <-- NO length of iform!
    i__1 = s_rsfi(&ici__1);
// [...]
```

The format strings are [declared as `CHARACTER*8`](https://github.com/iraf/iraf-v216/blob/9590f45760a4791f3305407fb51c87f1282b32be/pkg/tbtables/fitsio/ftc2dd.f#L13) and do not automatically have a `\0` appended at the end when they are created. Therefore, when the string is filled with blanks until the end, it will read one char over the end, which is hopefully a non-blank, but also may lead to a segmentation fault. Specifically this happens [in `unix/f2c/libf2c/fmt.c`](https://github.com/iraf/iraf-v216/blob/9590f45760a4791f3305407fb51c87f1282b32be/unix/f2c/libf2c/fmt.c#L113):

```
#define skip(s) while(*s==' ') s++
// [...]
 static
#ifdef KR_headers
char *f_s(s,curloc) char *s;#
else
const char *f_s(const char *s, int curloc)
#endif
{
	skip(s);
	if(*s++!='(')
	{
		return(NULL);
	}
	if(f__parenlvl++ ==1) f__revloc=curloc;
	if(op_gen(RET1,curloc,0,0)<0 ||
		(s=f_list(s))==NULL)
	{
		return(NULL);
	}
	skip(s); // <------------- here
	return(s);
}
```

This is probably a bug in f2c; however it is also not fixed in the recent versions as well. To work around this, a trailing `\0` is automatically added to the strings used in a `FMT` statement. The maximum length of the generated `FMT` strings is 7 ([in `ftc2dd.f`](https://github.com/iraf/iraf-v216/blob/9590f45760a4791f3305407fb51c87f1282b32be/pkg/tbtables/fitsio/ftc2dd.f#L27)), so adding one character will not exceed the declared length,
