### PR TITLE
WIP: First attempt to solve background CL tasks

### DIFF
--- a/lib/names
+++ b/lib/names
@@ -1340,6 +1340,7 @@ kflstx
 kflsty
 kfmkcp
 kfmkdr
+kfodpr
 kfpath
 kfprot
 kfrnam

--- a/lib/names
+++ b/lib/names
@@ -1869,6 +1869,7 @@ znotty
 zopcpr
 zopdir
 zopdpr
+zfodpr
 zopm70
 zopnbf
 zopngd

--- a/pkg/ecl/bkg.c
+++ b/pkg/ecl/bkg.c
@@ -4,6 +4,7 @@
 #define import_spp
 #define import_libc
 #define import_stdio
+#define	import_setjmp
 #define import_knames
 #define import_xwhen
 #define import_ctype
@@ -52,6 +53,7 @@
  */
 
 extern int cldebug;
+extern jmp_buf child_startup;
 
 /* We need to pass the pipe file names along to the bkg cl because the name
  * of the pipe file to use is determined AT PARSE TIME, not when the file
@@ -175,21 +177,16 @@ bkg_spawn (
 	/* Write bkgfile.  Delete any dreg bkg communication files.
 	 */
 	bkg_delfiles (jobno);
-	bkgfile = wbkgfile (jobno, cmd, NULL);
 
 	/* Spawn bkg job.
 	 */
-	sprintf (clprocess, "%s%s", CLDIR, CLPROCESS);
 	intr_disable();
-	jobtable[jobno-1].b_jobno = stat =
-	    c_propdpr (findexe (firstask->t_curpack, clprocess),
-		bkgfile, bkgmsg);
+	jobtable[jobno-1].b_jobno = stat = c_prfodpr();
 
-	if (stat == NULL) {
-	    c_delete (bkgfile);
+	if (stat < 0) {
 	    intr_enable();
 	    cl_error (E_IERR, "cannot spawn background CL");
-	} else {
+	} else if (stat > 0) { /* parent */
 	    bk = &jobtable[jobno-1];
 	    bk->b_flags = J_RUNNING;
 	    bk->b_clock = c_clktime (0L);
@@ -197,6 +194,9 @@ bkg_spawn (
 	    strncpy (bk->b_cmd, cmd, SZ_CMD);
 	    *(bk->b_cmd+SZ_CMD) = EOS;
 	    intr_enable();
+	} else { /* child */
+	    currentask->t_flags = firstask->t_flags = T_BATCH;
+	    longjmp(child_startup, 1);
 	}
 
 	eprintf ("[%d]\n", lastjobno = jobno);
@@ -442,18 +442,6 @@ bkg_delfiles (int job)
 }
 
 
-/* BKG_STARTUP -- Called by a background CL during process startup.  Read in
- * the bkgfile and restore runtime context of the parent.
- */
-void 
-bkg_startup (char *bkgfile)
-{
-	rbkgfile (bkgfile);
-	setclmodes (firstask);
-	currentask->t_flags = firstask->t_flags = T_BATCH;
-}
-
-
 /* BKG_ABORT -- Called by onint() in main.c when we get interrupted while
  * running as a bkg job.  Kill any and all background CL's WE may have
  * started, flush io, close any open pipe files, remove our job seq lock
@@ -480,170 +468,4 @@ bkg_abort (void)
 	}
 
 	fprintf (stderr, "\n[%d] killed\n", bkgno);
-}
-
-
-/* WBKGFILE -- Create a unique file, write and close the background file.
- * Jobno is the job number the new cl is to think its running for.
- * We don't use the global bkgno because that's OUR number, if we ourselves
- *   are background.
- * Return pointer to the new name.
- * No error return, but we may call error() and never return.
- */
-char *
-wbkgfile (
-    int jobno,			/* ordinal jobnumber of child	*/
-    char *cmd,			/* command to be run in bkg	*/
-    char *fname			/* filename for env file	*/
-)
-{
-	static	char *bkgwerr = "error writing background job file";
-	static	char bkgfile[SZ_PATHNAME];
-	struct	bkgfilehdr bh;
-	int	n, show_redefs=NO;
-	FILE	*fp;
-
-
-	/* If we're a normal background job no name was specified so 
-	 * create a unique uparm file.  Otherwise, use the specified
-	 * filename (e.g. for special onerr handling).
-	 */
-	if (fname == (char *)NULL)
-	    c_mktemp ("uparm$bkg", bkgfile, SZ_PATHNAME);
-	else {
-	    if (c_access (fname,0,0) == YES)
-		c_delete (fname);
-	    strncpy (bkgfile, fname, strlen(fname));
-	}
-
-	/* Open the file. */
-	if ((fp = fopen (bkgfile, "wb")) == NULL)
-	    cl_error (E_IERR, "unable to create background job file `%s'",
-		bkgfile);
-
-	for (n=0;  n < MAXPIPES;  n++)
-	    bh.b_pipetable[n] = pipetable[n];
-	bh.b_nextpipe = nextpipe;
-
-	strncpy (bh.b_cmd, cmd, SZ_BKCMD);
-
-	bh.b_magic	= BKG_MAGIC;
-	bh.b_bkgno	= jobno;
-	bh.b_ppid	= c_getpid();
-	bh.b_szstack	= STACKSIZ * BPI;
-	bh.b_szdict	= topd * BPI;
-	bh.b_dict 	= dictionary;
-	bh.b_topd 	= topd;
-	bh.b_maxd 	= maxd;
-	bh.b_parhead 	= parhead;
-	bh.b_pachead 	= pachead;
-	bh.b_pc 	= pc;
-	bh.b_topos 	= topos;
-	bh.b_basos 	= basos;
-	bh.b_topcs 	= topcs;
-	bh.b_firstask 	= firstask;
-	bh.b_currentask	= currentask;
-	bh.b_curpack 	= curpack;
-
-	/* Write the header structure, followed by the stack area and the
-	 * dictionary.
-	 */
-	if (fwrite ((char *)&bh, BKGHDRSIZ, 1, fp) == NULL)
-	    cl_error (E_IERR|E_P, bkgwerr);
-	if (fwrite ((char *)stack, STACKSIZ, BPI, fp) == NULL)
-	    cl_error (E_IERR|E_P, bkgwerr);
-	if (fwrite ((char *)dictionary, topd, BPI, fp) == NULL)
-	    cl_error (E_IERR|E_P, bkgwerr);
-
-	/* Write the environment as a sequence of SET statements in binary.
-	 * Append a blank line as a terminator.
-	 */
-	c_envlist (fileno(fp), "set ", show_redefs);
-	fputs ("\n", fp);
-
-	fclose (fp);
-	return (bkgfile);
-}
-
-
-/* RBKGFILE -- Read in and use background status file with given name.
- * Do not remove the file -- the system does that upon process termination
- * to signal the parent.  If an error occurs do not call cl_error since
- * we are called during process startup and error recovery is not yet
- * possible (a memory fault will result).
- */
-void 
-rbkgfile (char *bkgfile)
-{
-	char	set[SZ_ENVDEF];
-	struct	bkgfilehdr bh;
-	int	n;
-	FILE	*fp;
-
-
-	if ((fp = fopen (bkgfile, "rb")) == NULL) {
-	    fprintf (stderr,
-		"[B] ERROR: unable to open background job file `%s'\n",
-		bkgfile);
-	    clexit();
-	}
-
-	if (fread ((char *)&bh, BKGHDRSIZ, 1, fp) == NULL)
-	    goto abort_;
-	if (bh.b_magic != BKG_MAGIC) {
-	    fprintf (stderr, "[B] ERROR: bad magic in bkgfile '%s'\n", bkgfile);
-	    clexit();
-	}
-
-	/* The following assumes that the dictionary is statically allocated
-	 * and cannot move around.
-	 */
-	if (bh.b_dict != cl_dictbuf) {
-	    fprintf (stderr,
-		"BKG ERROR: new CL installed; logout and try again\n");
-	    clexit();
-	}
-
-	intr_disable();
-
-	for (n=0;  n < MAXPIPES;  n++)
-	    pipetable[n] = bh.b_pipetable[n];
-	nextpipe = bh.b_nextpipe;
-
-	bkgno		= bh.b_bkgno;
-	ppid		= bh.b_ppid;
-	dictionary 	= bh.b_dict;
-	topd	 	= bh.b_topd;
-	maxd 		= bh.b_maxd;
-	pachead 	= bh.b_pachead;
-	parhead 	= bh.b_parhead;
-	pc 		= bh.b_pc;
-	topos 		= bh.b_topos;
-	basos 		= bh.b_basos;
-	topcs 		= bh.b_topcs;
-	firstask 	= bh.b_firstask;
-	currentask 	= bh.b_currentask;
-	curpack 	= bh.b_curpack;
-
-	/* Read stack area and dictionary.
-	 */
-	if (fread ((char *)stack, bh.b_szstack, 1, fp) == NULL)
-	    goto abort_;
-	if (fread ((char *)dictionary, bh.b_szdict, 1, fp) == NULL)
-	    goto abort_;
-
-	/* Read and restore the environment.
-	 */
-	do {
-	    if (fgets (set, SZ_ENVDEF, fp) == NULL)
-		goto abort_;
-	} while (c_envscan (set));
-
-	intr_enable();
-	fclose (fp);
-	return;
-abort_:
-	intr_enable();
-	eprintf ("[B] ERROR: error reading background file\n");
-	clexit();
 }

--- a/pkg/ecl/main.c
+++ b/pkg/ecl/main.c
@@ -69,6 +69,7 @@ memel	cl_dictbuf[DICTSIZE];	/* the dictionary area			*/
 
 jmp_buf errenv;			/* cl_error() jumps here		*/
 jmp_buf intenv;			/* X_INT during process jumps here	*/
+jmp_buf child_startup;		/* child processes jump here            */
 int	validerrenv;		/* stays 0 until errenv gets set	*/
 int	loggingout;		/* set while processing logout file	*/
 int	gologout;		/* set when logout() is typed		*/
@@ -120,9 +121,11 @@ PKCHAR	*cmd;			/* host command line			*/
 	 * these fail.
 	 */
 	startup ();
+	if (setjmp(child_startup)) {
+	    *prtype = PR_DETACHED;
+	}
 
 	if (*prtype == PR_DETACHED) {
-	    bkg_startup ((char *)bkgfile);
 	    cpustart = c_cputime (0L);
 	    clkstart = c_clktime (0L);
 	    execute (BACKGROUND);

--- a/sys/NAMES
+++ b/sys/NAMES
@@ -2202,6 +2202,7 @@ kflstx          kflstx
 kflsty          kflsty
 kfmkcp          kfmkcp
 kfmkdr          kfmkdr
+kfodpr          kfodpr
 kfpath          kfpath
 kfprot          kfprot
 kfrnam          kfrnam

--- a/sys/NAMES
+++ b/sys/NAMES
@@ -792,6 +792,7 @@ c_prenvset      c_prenvset
 c_printf        c_printf
 c_prkill        c_prkill
 c_propdpr       c_propdpr
+c_prfodpr       c_prfodpr
 c_propen        c_propen
 c_prredir       c_prredir
 c_prsignal      c_prsignal
@@ -3819,6 +3820,7 @@ znotty          ZNOTTY
 zopcpr          ZOPCPR
 zopdir          ZOPDIR
 zopdpr          ZOPDPR
+zfodpr          ZFODPR
 zopnbf          ZOPNBF
 zopnks          ZOPNKS
 zopnlp          ZOPNLP

--- a/sys/etc/mkpkg
+++ b/sys/etc/mkpkg
@@ -87,6 +87,7 @@ libsys.a:
 	prkill.x	prd.com <config.h> <knet.h>
 	propcpr.x	prc.com <config.h> <fset.h> <knet.h> <prstat.h>\
 			<xwhen.h>
+	prfodpr.x	prd.com <config.h> <knet.h>
 	propdpr.x	prd.com <config.h> <knet.h>
 	propen.x	<knet.h>
 	proscmd.x	prc.com <config.h>

--- a/sys/etc/prd.com
+++ b/sys/etc/prd.com
@@ -1,8 +1,9 @@
 # Job table for detached processes.
 
+bool	first_time
 int	pr_jobcode[MAX_BKGJOBS]		# job code assigned by host system
 int	pr_active[MAX_BKGJOBS]		# set to NO if job is killed
 int	pr_exit_status[MAX_BKGJOBS]	# exit status of process
 pointer	pr_bkgfile[MAX_BKGJOBS]		# bkgfile filename (signals job term)
 
-common	/prdcom/ pr_jobcode, pr_active, pr_exit_status, pr_bkgfile
+common	/prdcom/ first_time, pr_jobcode, pr_active, pr_exit_status, pr_bkgfile

--- a/sys/etc/prdone.x
+++ b/sys/etc/prdone.x
@@ -13,11 +13,15 @@ int procedure prdone (job)
 
 int	job			# job number (slot number in job table)
 int	access()
+int	ztsdpr()
 include	"prd.com"
 
 begin
 	if (pr_jobcode[job] == NULL)
 	    call syserr (SYS_PRBKGNF)
+
+	if (ztsdpr (pr_jobcode[job]) != ERR)
+	    return (NO)
 
 	if (access (Memc[pr_bkgfile[job]], 0, 0) == YES)
 	    return (NO)

--- a/sys/etc/prfodpr.x
+++ b/sys/etc/prfodpr.x
@@ -1,0 +1,48 @@
+# Copyright(c) 1986 Association of Universities for Research in Astronomy Inc.
+
+include	<knet.h>
+include	<config.h>
+include	<syserr.h>
+
+# PRFODPR -- Fork a detached process.  A detached process runs independently of
+# and asynchronous with the parent, with no direct communications (i.e., like
+# the IPC channels of connected subprocesses).
+
+int procedure prfodpr ()
+
+int	jobcode, pr
+errchk	fmapfn, syserrs, malloc
+include	"prd.com"
+
+begin
+	# First time initialization of the job table.
+	if (first_time) {
+	    do pr = 1, MAX_BKGJOBS {
+		pr_jobcode[pr] = NULL
+		pr_bkgfile[pr] = NULL
+	    }
+	    first_time = false
+	}
+
+	# Get job slot.
+	for (pr=1;  pr <= MAX_BKGJOBS;  pr=pr+1)
+	    if (pr_jobcode[pr] == NULL)
+		break
+	if (pr > MAX_BKGJOBS)
+	    call syserrs (SYS_PRBKGOVFL, "fork")
+
+	# Spawn or enqueue detached process.
+	call zfodpr (jobcode)
+	if (jobcode == ERR)
+	    call syserrs (SYS_PRBKGOPEN, "fork")
+
+        # On client side, return immediately
+        if (jobcode == NULL)
+	    return (NULL)
+
+	# Set up bkg job descriptor.
+	pr_jobcode[pr] = jobcode
+	pr_active[pr] = YES
+
+	return (pr)
+end

--- a/sys/etc/propdpr.x
+++ b/sys/etc/propdpr.x
@@ -19,12 +19,11 @@ char	process[ARB]		# vfn of executable process file
 char	bkgfile[ARB]		# vfn of background file
 char	bkgmsg[ARB]		# control string for kernel
 
-bool	first_time
 int	jobcode, pr
 pointer	sp, process_osfn, bkgfile_osfn, pk_bkgmsg
-data	first_time /true/
 errchk	fmapfn, syserrs, malloc
 include	"prd.com"
+data	first_time /true/
 
 begin
 	call smark (sp)

--- a/sys/ki/kopdpr.x
+++ b/sys/ki/kopdpr.x
@@ -57,3 +57,15 @@ begin
 
 	call sfree (sp)
 end
+
+# KFODPR -- Fork a detached process.
+
+procedure kfodpr (jobcode)
+
+int	jobcode			# receives job code of process
+int	ki_getchan()
+begin
+	call zfodpr (jobcode)
+	if (jobcode != ERR)
+	    jobcode = ki_getchan (NULL, jobcode)
+end

--- a/sys/libc/cprdet.c
+++ b/sys/libc/cprdet.c
@@ -57,6 +57,20 @@ c_propdpr (
 }
 
 
+/* C_PRFODPR -- Open a detached process.
+*/
+unsigned int
+c_prfodpr (
+)
+{
+	unsigned job;
+	iferr (job = PRFODPR ())
+	    return (ERR);
+	else
+	    return (job);
+}
+
+
 /* C_PRCLDPR -- Close a detached process.  Wait (indefinitely) for process
 ** termination, then free all system resources allocated to the process.
 ** Should be called if a detached process terminated while the parent is

--- a/sys/libc/libc_proto.h
+++ b/sys/libc/libc_proto.h
@@ -120,6 +120,7 @@ extern int c_prchdir(int pid, char *newdir);
 extern int c_prenvset(int pid, char *envvar, char *value);
 /* cprdet.c */
 extern unsigned int c_propdpr(char *process, char *bkgfile, char *bkgmsg);
+extern unsigned int c_prfodpr(void);
 extern int c_prcldpr(unsigned job);
 extern int c_prdone(unsigned job);
 extern int c_prkill(unsigned job);

--- a/test/programming.md
+++ b/test/programming.md
@@ -34,6 +34,18 @@ sequence of tasks.  A Terminal Script is essentially a compound
 statement, but uses some of the simple programming tools provided by
 the CL.
 
+CL may execute a task in the background:
+
+```
+cl> sleep 1 ; print one &
+[1]
+cl> print two ; sleep 2 ; print three
+two
+one
+[0] done  0.0 0:00 0%
+two
+```
+
 Now we check some control structures. First create a list file with a
 `for` loop
 
@@ -64,7 +76,6 @@ File: `while.cl`
 list = "sqr.lis"
 while (fscan(list, i, j) != EOF) print(i, j)
 ```
-
 
 
 ```

--- a/unix/hlib/knet.h
+++ b/unix/hlib/knet.h
@@ -47,6 +47,7 @@ define	zflstx	kflstx
 define	zflsty	kflsty
 define	zfmkcp	kfmkcp
 define	zfmkdr	kfmkdr
+define	zfodpr  kfodpr
 define	zfpath	kfpath
 define	zfprot	kfprot
 define	zfrnam	kfrnam

--- a/unix/hlib/libc/knames.h
+++ b/unix/hlib/libc/knames.h
@@ -225,6 +225,7 @@
 #define zflsty_	kflsty_
 #define zfmkcp_	kfmkcp_
 #define zfmkdr_	kfmkdr_
+#define zfodpr_	kfodpr_
 #define zfprot_	kfprot_
 #define zfrnam_	kfrnam_
 #define zfrmdr_	kfrmdr_

--- a/unix/hlib/libc/knames.h
+++ b/unix/hlib/libc/knames.h
@@ -124,6 +124,7 @@
 #define	ZNOTTY		znotty_
 #define	ZOPCPR		zopcpr_
 #define	ZOPDIR		zopdir_
+#define	ZFODPR		zfodpr_
 #define	ZOPDPR		zopdpr_
 #define	ZOPNBF		zopnbf_
 #define	ZOPNGD		zopngd_
@@ -151,6 +152,7 @@
 #define	ZSTTSF		zsttsf_
 #define	ZSTTTX		zstttx_
 #define	ZSTTTY		zsttty_
+#define ZTSDPR		ztsdpr_
 #define	ZSVJMP		zsvjmp_
 #define	ZTSLEE		ztslee_
 #define	ZWMSEC		zwmsec_

--- a/unix/hlib/libc/kproto.h
+++ b/unix/hlib/libc/kproto.h
@@ -216,6 +216,7 @@ extern int zcldir_(int *chan, int *status);
 extern int zgfdir_(int *chan, shortint *outstr, int *maxch, int *status);
 /* zopdpr.c */
 extern int zopdpr_(shortint *osfn, shortint *bkgfile, shortint *queue, int *jobcode);
+extern int zfodpr_(int *jobcode);
 extern int zcldpr_(int *jobcode, int *killflag, int *exit_status);
 /* zoscmd.c */
 extern int zoscmd_(shortint *oscmd, shortint *stdin_file, shortint *stdout_file, shortint *stderr_file, int *status);

--- a/unix/hlib/libc/xnames.h
+++ b/unix/hlib/libc/xnames.h
@@ -159,6 +159,7 @@
 #define	PRKILL		prkill_
 #define	PROPCPR		propcr_
 #define	PROPDPR		propdr_
+#define	PRFODPR		prfodr_
 #define	PROPEN		propen_
 #define	PROTECT		protet_
 #define	PRREDIR		prredr_

--- a/unix/os/zxwhen.c
+++ b/unix/os/zxwhen.c
@@ -24,7 +24,7 @@
 /* Set the following nonzero to cause process termination with a core dump
  * when the first signal occurs.
  */
-int debug_sig = 0;
+int debug_sig = 1;
 
 
 /* If the OS allows, cancel any buffered output. If the OS doesn't, 


### PR DESCRIPTION
The problem is that in the background file, there are pointers transmitted to the child. This requires that parent and child use the same (local) address space, which is not generally true. Address space layout randomization (ASLR).

This patch (ed2da96a3c03fc93a8235057aca34d338422ed62) replaces the direct pointers for firstask, currentask, and curpack in the background file by the offsets to their base pointers, restoring the prober pointers on the client. This is however not enough, since the task structure itself also contains a number of pointers, each of which would have need to be converted in the same manner. Therefore, we still get a segfault here. 