### PR TITLE
Don't check for updates

### DIFF
--- a/unix/hlib/login.cl
+++ b/unix/hlib/login.cl
@@ -141,9 +141,6 @@ else {
 
 
 #============================================================================
-# Check for updates to the system
-chkupdate
-
 # Notify the user if we're using the global login.
 path (".") | scan (s1)
 if ( osfn("home$") != substr (s1, strldx("!",s1)+1, strlen(s1)) ) {


### PR DESCRIPTION
Since the official IRAF (iraf.noao.edu) is not going to be updated anymore, there is no reason to check for updates then. To protect users privacy, and to avoid startup delays, this PR will disable the check.
