### PR TITLE
add macro variants __PPC64__ __powerpc64__ to zsvjmp.S

### DIFF
--- a/unix/as.linux64/zsvjmp.S
+++ b/unix/as.linux64/zsvjmp.S
@@ -30,7 +30,7 @@
 
 #if defined(__aarch64__)
 	.arch armv8-a
-#elif defined(__ppc64__)
+#elif defined(__ppc64__) || defined(__PPC64__) || defined(__powerpc64__)
 	.abiversion 2
 #endif
 	.align 2
@@ -72,7 +72,7 @@ zsvjmp_:
 	jr $t9				// Tail call sigsetjmp
 	.end	zsvjmp_
 
-#elif defined(__ppc64__)
+#elif defined(__ppc64__) || defined(__PPC64__) || defined(__powerpc64__)
 
 // Use VRSAVE (unused in Linux) and stack reserved area (SP+12) to
 // save the return address (LR) which is lost after bl __sigsetjmp.


### PR DESCRIPTION
In zsvjmp.S for linux64 we currently use __ppc64__ to select the PPC64 platform. On Fedora (and maybe others?) this one is not defined, but __PPC64__ and/or __powerpc64__. Therefore I suggest to add these ones here. This is also common practise e.g. in Qt libraries.